### PR TITLE
add metadata parse in suricata rules

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -351,7 +351,7 @@ func (r *Rule) option(key item, l *lexer) error {
 			if len(meta_tmp) != 2 {
 				return fmt.Errorf("invalid metadata definition: %s", meta_tmp)
 			}
-			r.Metas = append(r.Metas, &Metadata{Key: meta_tmp[0], Value: meta_tmp[1]})
+			r.Metas = append(r.Metas, &Metadata{Key: strings.TrimSpace(meta_tmp[0]), Value: strings.TrimSpace(meta_tmp[1])})
 		}
 	case "sid":
 		nextItem := l.nextItem()

--- a/parser.go
+++ b/parser.go
@@ -58,11 +58,17 @@ type Rule struct {
 	PCREs []*PCRE
 	// Tags is a map of tag names to tag values (e.g. classtype:trojan).
 	Tags map[string]string
-	//parse metadata
-	Metas  map[string]string
+	//Metas is a slice of Metadata 
+	Metas  []*Metadata
 }
 
 // TODO: Ensure all values either begin with $ (variable) or they are valid IPNet/int.
+
+//Metadata describe metadata in  key-value struct
+type Metadata struct{
+	Key 	string 
+	Value	string
+}
 
 // Network describes the IP addresses and port numbers used in a rule.
 type Network struct {
@@ -339,21 +345,13 @@ func (r *Rule) option(key item, l *lexer) error {
 		if nextItem.typ != itemOptionValue {
 			return errors.New("no valid value for metadata")
 		}
-		if r.Metas == nil{
-			r.Metas = make(map[string]string)
-		}
 		metas := metaSplitRE.Split(nextItem.value, -1)
 		for _,kv := range metas{
 			meta_tmp := strings.SplitN(kv, " ", 2)
 			if len(meta_tmp) != 2 {
 				return fmt.Errorf("invalid metadata definition: %s", meta_tmp)
 			}
-			// append same key's content
-			if _,ok := r.Metas[strings.TrimSpace(meta_tmp[0])]; ok{
-				r.Metas[strings.TrimSpace(meta_tmp[0])] = r.Metas[strings.TrimSpace(meta_tmp[0])] + "," + strings.TrimSpace(meta_tmp[1])
-			}else{
-				r.Metas[strings.TrimSpace(meta_tmp[0])] = strings.TrimSpace(meta_tmp[1])	
-			}	
+			r.Metas = append(r.Metas, &Metadata{Key: meta_tmp[0], Value: meta_tmp[1]})
 		}
 	case "sid":
 		nextItem := l.nextItem()

--- a/parser.go
+++ b/parser.go
@@ -129,7 +129,7 @@ var hexRE = regexp.MustCompile(`(?i)(\|(?:\s*[a-f0-9]{2}\s*)+\|)`)
 var escapeRE = regexp.MustCompile(`([()+.'\\])`)
 
 // metaSplitRE matches string in metadata
-var metaSplitRE = regexp.MustCompile(`,\s*`) //global
+var metaSplitRE = regexp.MustCompile(`,\s*`)
 
 // parseContent decodes rule content match. For now it only takes care of escaped and hex
 // encoded content.
@@ -339,6 +339,9 @@ func (r *Rule) option(key item, l *lexer) error {
 		if nextItem.typ != itemOptionValue {
 			return errors.New("no valid value for metadata")
 		}
+		if r.Metas == nil{
+			r.Metas = make(map[string]string)
+		}
 		metas := metaSplitRE.Split(nextItem.value, -1)
 		for _,kv := range metas{
 			meta_tmp := strings.SplitN(kv, " ", 2)
@@ -478,7 +481,7 @@ func ParseRule(rule string) (*Rule, error) {
 	if err != nil {
 		return nil, err
 	}
-	r := &Rule{Metas:make(map[string]string)}
+	r := &Rule{}
 	for item := l.nextItem(); item.typ != itemEOR && item.typ != itemEOF && err == nil; item = l.nextItem() {
 		switch item.typ {
 		case itemAction:

--- a/parser.go
+++ b/parser.go
@@ -58,6 +58,8 @@ type Rule struct {
 	PCREs []*PCRE
 	// Tags is a map of tag names to tag values (e.g. classtype:trojan).
 	Tags map[string]string
+	//parse metadata
+	Metas  map[string]string
 }
 
 // TODO: Ensure all values either begin with $ (variable) or they are valid IPNet/int.
@@ -329,6 +331,20 @@ func (r *Rule) option(key item, l *lexer) error {
 			return fmt.Errorf("invalid reference definition: %s", refs)
 		}
 		r.References = append(r.References, &Reference{Type: refs[0], Value: refs[1]})
+	case "metadata":
+		nextItem := l.nextItem()
+		if nextItem.typ != itemOptionValue {
+			return errors.New("no valid value for metadata")
+		}
+		metas := strings.Split(nextItem.value, ", ")
+		r.Metas = make(map[string]string)
+		for _,kv := range metas{
+			meta_tmp := strings.SplitN(kv, " ", 2)
+			if len(meta_tmp) != 2 {
+				return fmt.Errorf("invalid metadata definition: %s", metas)
+			}
+			r.Metas[meta_tmp[0]] = meta_tmp[1]	
+		}
 	case "sid":
 		nextItem := l.nextItem()
 		if nextItem.typ != itemOptionValue {

--- a/parser.go
+++ b/parser.go
@@ -341,7 +341,7 @@ func (r *Rule) option(key item, l *lexer) error {
 		for _,kv := range metas{
 			meta_tmp := strings.SplitN(kv, " ", 2)
 			if len(meta_tmp) != 2 {
-				return fmt.Errorf("invalid metadata definition: %s", metas)
+				return fmt.Errorf("invalid metadata definition: %s", meta_tmp)
 			}
 			r.Metas[meta_tmp[0]] = meta_tmp[1]	
 		}

--- a/parser.go
+++ b/parser.go
@@ -348,7 +348,12 @@ func (r *Rule) option(key item, l *lexer) error {
 			if len(meta_tmp) != 2 {
 				return fmt.Errorf("invalid metadata definition: %s", meta_tmp)
 			}
-			r.Metas[strings.TrimSpace(meta_tmp[0])] = strings.TrimSpace(meta_tmp[1])	
+			// append same key's content
+			if _,ok := r.Metas[strings.TrimSpace(meta_tmp[0])]; ok{
+				r.Metas[strings.TrimSpace(meta_tmp[0])] = r.Metas[strings.TrimSpace(meta_tmp[0])] + "," + strings.TrimSpace(meta_tmp[1])
+			}else{
+				r.Metas[strings.TrimSpace(meta_tmp[0])] = strings.TrimSpace(meta_tmp[1])	
+			}	
 		}
 	case "sid":
 		nextItem := l.nextItem()

--- a/parser_test.go
+++ b/parser_test.go
@@ -321,7 +321,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
-				Metas: map[string]string{"policy":"security-ips drop", "ruleset":"community" ,"service":"http", "impact_flag":"red"},
+				Metas: map[string]string{"policy":"balanced-ips drop,security-ips drop", "ruleset":"community" ,"service":"http", "impact_flag":"red"},
 			},
 		},
 		{

--- a/parser_test.go
+++ b/parser_test.go
@@ -321,7 +321,13 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
-				Metas: map[string]string{"policy":"balanced-ips drop,security-ips drop", "ruleset":"community" ,"service":"http", "impact_flag":"red"},
+				Metas: []*Metadata{
+					&Metadata{Key: "impact_flag", Value: "red"},
+					&Metadata{Key: "policy", Value: "balanced-ips drop"},
+					&Metadata{Key: "policy", Value: "security-ips drop"},
+					&Metadata{Key: "ruleset", Value: "community"},
+					&Metadata{Key: "service", Value: "http"},
+				},
 			},
 		},
 		{
@@ -364,7 +370,10 @@ func TestParseRule(t *testing.T) {
 					&Content{Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},Options: []*ContentOption{ &ContentOption{"distance", 0}}},
 				},
 				Tags: map[string]string{"flow": "established", "classtype": "shellcode-detect"},
-				Metas: map[string]string{"created_at":"2010_07_30", "updated_at":"2010_07_30"},
+				Metas: []*Metadata{
+					&Metadata{Key: "created_at", Value: "2010_07_30"},
+					&Metadata{Key: "updated_at", Value: "2010_07_30"},
+				},
 			},
 		},
 		{
@@ -385,7 +394,11 @@ func TestParseRule(t *testing.T) {
 					&Content{Pattern: []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22}, DataPosition:1, Options: []*ContentOption{ &ContentOption{"nocase", 0},&ContentOption{"distance", 0} }, FastPattern: FastPattern{Enabled:false, Length:0, Offset:0}, Negate:false},
 				},
 				Tags: map[string]string{"flow": "established,from_server", "classtype": "trojan-activity"},
-				Metas: map[string]string{"former_category":"CURRENT_EVENTS", "created_at":"2015_10_22", "updated_at":"2018_07_12"},
+				Metas: []*Metadata{
+					&Metadata{Key: "former_category", Value: "CURRENT_EVENTS"},
+					&Metadata{Key: "created_at", Value: "2015_10_22"},
+					&Metadata{Key: "updated_at", Value: "2018_07_12"},
+				},
 			},
 		},
 		// Errors

--- a/parser_test.go
+++ b/parser_test.go
@@ -346,6 +346,26 @@ func TestParseRule(t *testing.T) {
 				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
 			},
 		},
+		{
+			name: "Metadata",
+			rule: `alert tcp any any -> any any (msg:"ET SHELLCODE Berlin Shellcode"; flow:established; content:"|31 c9 b1 fc 80 73 0c|"; content:"|43 e2 8b 9f|"; distance:0; reference:url,doc.emergingthreats.net/2009256; classtype:shellcode-detect; sid:2009256; rev:3; metadata:created_at 2010_07_30, updated_at 2010_07_30;)`,
+			want: &Rule{
+				Action:      "alert",
+				Protocol:    "tcp",
+				Source:      Network{Nets: []string{"any"}, Ports: []string{"any"}},
+				Destination: Network{Nets: []string{"any"}, Ports: []string{"any"}},
+				SID:         2009256,
+				Revision:    3,
+				Description: "ET SHELLCODE Berlin Shellcode",
+				References:  []*Reference{&Reference{Type: "url", Value: "doc.emergingthreats.net/2009256"}},
+				Contents: []*Content{
+					&Content{Pattern: []byte{0x31, 0xc9, 0xb1, 0xfc, 0x80, 0x73, 0x0c}}, 
+					&Content{Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},Options: []*ContentOption{ &ContentOption{"distance", 0}}},
+				},
+				Tags: map[string]string{"flow": "established", "classtype": "shellcode-detect"},
+				Metas: map[string]string{"created_at":"2010_07_30", "updated_at":"2010_07_30"},
+			},
+		},
 		// Errors
 		//TODO: Fix lexer with invalid direction. This test causes an infinite loop.
 		//{

--- a/parser_test.go
+++ b/parser_test.go
@@ -366,6 +366,27 @@ func TestParseRule(t *testing.T) {
 				Metas: map[string]string{"created_at":"2010_07_30", "updated_at":"2010_07_30"},
 			},
 		},
+		{
+			name: "Multi Metadata",
+			rule: `alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET CURRENT_EVENTS Chase Account Phish Landing Oct 22"; flow:established,from_server; file_data; content:"<title>Sign in</title>"; content:"name=chalbhai"; fast_pattern; nocase; distance:0; content:"required title=|22|Please Enter Right Value|22|"; nocase; distance:0; content:"required title=|22|Please Enter Right Value|22|"; nocase; distance:0; metadata: former_category CURRENT_EVENTS; classtype:trojan-activity; sid:2025692; rev:2; metadata:created_at 2015_10_22, updated_at 2018_07_12;)`,
+			want: &Rule{
+				Action:      "alert",
+				Protocol:    "http",
+				Source:      Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Destination: Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
+				SID:         2025692,
+				Revision:    2,
+				Description: "ET CURRENT_EVENTS Chase Account Phish Landing Oct 22",
+				Contents: []*Content{
+					&Content{Pattern: []byte{0x3c, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3e, 0x53, 0x69, 0x67, 0x6e, 0x20, 0x69, 0x6e, 0x3c, 0x2f, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3e}, DataPosition:1, FastPattern: FastPattern{Enabled:false, Length:0, Offset:0}, Negate:false}, 
+					&Content{Pattern: []byte{0x6e, 0x61, 0x6d, 0x65, 0x3d, 0x63, 0x68, 0x61, 0x6c, 0x62, 0x68, 0x61, 0x69}, DataPosition:1, Options: []*ContentOption{ &ContentOption{"nocase", 0}, &ContentOption{"distance", 0} }, FastPattern: FastPattern{Enabled:true, Length:0, Offset:0}, Negate:false},
+					&Content{Pattern: []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22}, DataPosition:1, Options: []*ContentOption{ &ContentOption{"nocase", 0},&ContentOption{"distance", 0} }, FastPattern: FastPattern{Enabled:false, Length:0, Offset:0}, Negate:false},
+					&Content{Pattern: []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22}, DataPosition:1, Options: []*ContentOption{ &ContentOption{"nocase", 0},&ContentOption{"distance", 0} }, FastPattern: FastPattern{Enabled:false, Length:0, Offset:0}, Negate:false},
+				},
+				Tags: map[string]string{"flow": "established,from_server", "classtype": "trojan-activity"},
+				Metas: map[string]string{"former_category":"CURRENT_EVENTS", "created_at":"2015_10_22", "updated_at":"2018_07_12"},
+			},
+		},
 		// Errors
 		//TODO: Fix lexer with invalid direction. This test causes an infinite loop.
 		//{

--- a/parser_test.go
+++ b/parser_test.go
@@ -321,6 +321,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
+				Metas: map[string]string{"policy":"security-ips drop", "ruleset":"community" ,"service":"http", "impact_flag":"red"},
 			},
 		},
 		{


### PR DESCRIPTION
add support for parsing metadata column in suricate rules.
rules looks like below:
alert http $EXTERNAL_NET any -> $HTTP_SERVERS $HTTP_PORTS (msg:"ET WEB_SPECIFIC_APPS Aktueldownload Haber script SQL Injection Attempt -- rss.asp kid DELETE"; flow:established,to_server; content:"/rss.asp?"; nocase; http_uri; content:"kid="; nocase; http_uri; content:"DELETE"; nocase; http_uri; pcre:"/DELETE.+FROM/Ui"; reference:cve,CVE-2007-1016; reference:url,www.frsirt.com/english/advisories/2007/0620; reference:url,doc.emergingthreats.net/2004896; classtype:web-application-attack; sid:2004896; rev:7; **_metadata:affected_product Web_Server_Applications, attack_target Web_Server, deployment Datacenter, tag SQL_Injection, signature_severity Major, created_at 2010_07_30, updated_at 2016_07_01;_**)