### PR TITLE
Clean up tests to make them more readable

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -15,6 +15,10 @@ limitations under the License.
 
 package gonids
 
+// TODO:
+//	Format long datas
+//	Make "byte" patterns more readable
+
 import (
 	"reflect"
 	"testing"
@@ -60,19 +64,25 @@ func TestContentToRegexp(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "simple content",
-			input: &Content{Pattern: []byte("abcd")},
-			want:  `abcd`,
+			name: "simple content",
+			input: &Content{
+				Pattern: []byte("abcd"),
+			},
+			want: `abcd`,
 		},
 		{
-			name:  "escaped content",
-			input: &Content{Pattern: []byte("abcd;ef")},
-			want:  `abcd;ef`,
+			name: "escaped content",
+			input: &Content{
+				Pattern: []byte("abcd;ef"),
+			},
+			want: `abcd;ef`,
 		},
 		{
-			name:  "complex escaped content",
-			input: &Content{Pattern: []byte("abcd;:\r\ne\rf")},
-			want:  `abcd;:\.\.e\.f`,
+			name: "complex escaped content",
+			input: &Content{
+				Pattern: []byte("abcd;:\r\ne\rf"),
+			},
+			want: `abcd;:\.\.e\.f`,
 		},
 	} {
 		got := tt.input.ToRegexp()
@@ -90,19 +100,25 @@ func TestContentFormatPattern(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:  "simple content",
-			input: &Content{Pattern: []byte("abcd")},
-			want:  "abcd",
+			name: "simple content",
+			input: &Content{
+				Pattern: []byte("abcd"),
+			},
+			want: "abcd",
 		},
 		{
-			name:  "escaped content",
-			input: &Content{Pattern: []byte("abcd;ef")},
-			want:  "abcd|3B|ef",
+			name: "escaped content",
+			input: &Content{
+				Pattern: []byte("abcd;ef"),
+			},
+			want: "abcd|3B|ef",
 		},
 		{
-			name:  "complex escaped content",
-			input: &Content{Pattern: []byte("abcd;:\r\ne\rf")},
-			want:  "abcd|3B 3A 0D 0A|e|0D|f",
+			name: "complex escaped content",
+			input: &Content{
+				Pattern: []byte("abcd;:\r\ne\rf"),
+			},
+			want: "abcd|3B 3A 0D 0A|e|0D|f",
 		},
 	} {
 		got := tt.input.FormatPattern()
@@ -128,144 +144,255 @@ func TestParseRule(t *testing.T) {
 			name: "simple content",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41, 0x41}}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"),
+					},
+				},
 			},
 		},
 		{
 			name: "commented rule content",
 			rule: `#alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
 			want: &Rule{
-				Disabled:    true,
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Disabled: true,
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41, 0x41}}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"),
+					},
+				},
 			},
 		},
 		{
 			name: "bidirectional",
 			rule: `alert udp $HOME_NET any <> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
 			want: &Rule{
-				Action:        "alert",
-				Protocol:      "udp",
-				Source:        Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination:   Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				Bidirectional: true,
 				SID:           1337,
 				Revision:      2,
 				Description:   "foo",
-				Contents:      []*Content{&Content{Pattern: []byte{0x41, 0x41}}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"),
+					},
+				},
 			},
 		},
 		{
 			name: "not content",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA");`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41, 0x41}, Negate: true}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"), Negate: true},
+				},
 			},
 		},
 		{
 			name: "multiple contents",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; content:"BB");`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents: []*Content{&Content{Pattern: []byte{0x41, 0x41}},
-					&Content{Pattern: []byte{0x42, 0x42}}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"),
+					},
+					&Content{
+						Pattern: []byte("BB"),
+					},
+				},
 			},
 		},
 		{
 			name: "hex content",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A|42 43|D|45|");`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41, 0x42, 0x43, 0x44, 0x45}}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte{'A', 0x42, 0x43, 'D', 0x45},
+					},
+				},
 			},
 		},
 		{
 			name: "tags",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; classtype:foo);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41, 0x41}, Negate: true}},
-				Tags:        map[string]string{"classtype": "foo"},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"), Negate: true},
+				},
+				Tags: map[string]string{"classtype": "foo"},
 			},
 		},
 		{
 			name: "references",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A"; reference:cve,2014; reference:url,www.suricata-ids.org);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents:    []*Content{&Content{Pattern: []byte{0x41}}},
-				References:  []*Reference{&Reference{Type: "cve", Value: "2014"}, &Reference{Type: "url", Value: "www.suricata-ids.org"}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("A"),
+					},
+				},
+				References: []*Reference{
+					&Reference{Type: "cve", Value: "2014"},
+					&Reference{Type: "url", Value: "www.suricata-ids.org"},
+				},
 			},
 		},
 		{
 			name: "content options",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; http_header; offset:3);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1337,
 				Description: "foo",
-				Contents: []*Content{&Content{
-					Pattern: []byte{0x41, 0x41},
-					Negate:  true,
-					Options: []*ContentOption{&ContentOption{"http_header", 0}, &ContentOption{"offset", 3}},
-				}},
+				Contents: []*Content{
+					&Content{
+						Pattern: []byte("AA"),
+						Negate:  true,
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+							&ContentOption{"offset", 3},
+						},
+					},
+				},
 			},
 		},
 		{
 			name: "multiple contents and options",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern; content:"B"; http_uri);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1,
 				Description: "a",
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x41}, Options: []*ContentOption{&ContentOption{"http_header", 0}}, FastPattern: FastPattern{Enabled: true}},
-					&Content{Pattern: []byte{0x42}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						Pattern: []byte("A"),
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+						},
+						FastPattern: FastPattern{Enabled: true},
+					},
+					&Content{
+						Pattern: []byte("B"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 			},
 		},
@@ -273,15 +400,33 @@ func TestParseRule(t *testing.T) {
 			name: "multiple contents and multiple options",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern:0,42; nocase; content:"B"; http_uri);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1,
 				Description: "a",
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x41}, Options: []*ContentOption{&ContentOption{"http_header", 0}, &ContentOption{"nocase", 0}}, FastPattern: FastPattern{Enabled: true, Offset: 0, Length: 42}},
-					&Content{Pattern: []byte{0x42}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						Pattern: []byte("A"),
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+							&ContentOption{"nocase", 0},
+						},
+						FastPattern: FastPattern{Enabled: true, Offset: 0, Length: 42},
+					},
+					&Content{
+						Pattern: []byte("B"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 			},
 		},
@@ -289,15 +434,34 @@ func TestParseRule(t *testing.T) {
 			name: "multiple contents with file_data",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; file_data; content:"A"; http_header; nocase; content:"B"; http_uri);`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1,
 				Description: "a",
 				Contents: []*Content{
-					&Content{DataPosition: fileData, Pattern: []byte{0x41}, Options: []*ContentOption{&ContentOption{"http_header", 0}, &ContentOption{"nocase", 0}}},
-					&Content{DataPosition: fileData, Pattern: []byte{0x42}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						DataPosition: fileData,
+						Pattern:      []byte("A"),
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+							&ContentOption{"nocase", 0},
+						},
+					},
+					&Content{
+						DataPosition: fileData,
+						Pattern:      []byte("B"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 			},
 		},
@@ -305,16 +469,41 @@ func TestParseRule(t *testing.T) {
 			name: "multiple contents with file_data and pkt_data",
 			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; file_data; content:"A"; http_header; nocase; content:"B"; http_uri; pkt_data; content:"C"; http_uri;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "udp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "udp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1,
 				Description: "a",
 				Contents: []*Content{
-					&Content{DataPosition: fileData, Pattern: []byte{0x41}, Options: []*ContentOption{&ContentOption{"http_header", 0}, &ContentOption{"nocase", 0}}},
-					&Content{DataPosition: fileData, Pattern: []byte{0x42}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
-					&Content{DataPosition: pktData, Pattern: []byte{0x43}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						DataPosition: fileData,
+						Pattern:      []byte("A"),
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+							&ContentOption{"nocase", 0},
+						},
+					},
+					&Content{
+						DataPosition: fileData,
+						Pattern:      []byte("B"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
+					&Content{
+						DataPosition: pktData,
+						Pattern:      []byte("C"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 			},
 		},
@@ -322,16 +511,34 @@ func TestParseRule(t *testing.T) {
 			name: "http sticky buffer",
 			rule: `alert http $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; http_request_line; content:"A"; content:"B"; pkt_data; content:"C"; http_uri;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "http",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         1,
 				Description: "a",
 				Contents: []*Content{
-					&Content{DataPosition: httpRequestLine, Pattern: []byte{0x41}, Options: nil},
-					&Content{DataPosition: httpRequestLine, Pattern: []byte{0x42}, Options: nil},
-					&Content{DataPosition: pktData, Pattern: []byte{0x43}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						DataPosition: httpRequestLine,
+						Pattern:      []byte("A"),
+					},
+					&Content{
+						DataPosition: httpRequestLine,
+						Pattern:      []byte("B"),
+					},
+					&Content{
+						DataPosition: pktData,
+						Pattern:      []byte("C"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 			},
 		},
@@ -339,25 +546,44 @@ func TestParseRule(t *testing.T) {
 			name: "Complex VRT rule",
 			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"VRT BLACKLIST URI request for known malicious URI - /tongji.js"; flow:to_server,established; content:"/tongji.js"; fast_pattern:only; http_uri; content:"Host|3A| "; http_header; pcre:"/Host\x3a[^\r\n]*?\.tongji/Hi"; metadata:impact_flag red, policy balanced-ips drop, policy security-ips drop, ruleset community, service http; reference:url,labs.snort.org/docs/17904.html; classtype:trojan-activity; sid:17904; rev:6;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "tcp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"$HTTP_PORTS"}},
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"$HTTP_PORTS"},
+				},
 				SID:         17904,
 				Revision:    6,
 				Description: "VRT BLACKLIST URI request for known malicious URI - /tongji.js",
 				References:  []*Reference{&Reference{Type: "url", Value: "labs.snort.org/docs/17904.html"}},
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x2f, 0x74, 0x6f, 0x6e, 0x67, 0x6a, 0x69, 0x2e, 0x6a, 0x73}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}, FastPattern: FastPattern{Enabled: true, Only: true}},
-					&Content{Pattern: []byte{0x48, 0x6f, 0x73, 0x74, 0x3a, 0x20}, Options: []*ContentOption{&ContentOption{"http_header", 0}}},
+					&Content{
+						Pattern: []byte("/tongji.js"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+						FastPattern: FastPattern{Enabled: true, Only: true},
+					},
+					&Content{
+						Pattern: append([]byte("Host"), 0x3a, 0x20),
+						Options: []*ContentOption{
+							&ContentOption{"http_header", 0},
+						},
+					},
 				},
 				PCREs: []*PCRE{
 					&PCRE{
-						Pattern: []byte{0x48, 0x6f, 0x73, 0x74, 0x5c, 0x78, 0x33, 0x61, 0x5b, 0x5e, 0x5c, 0x72, 0x5c, 0x6e, 0x5d, 0x2a, 0x3f, 0x5c, 0x2e, 0x74, 0x6f, 0x6e, 0x67, 0x6a, 0x69},
-						Options: []byte{0x48, 0x69},
+						Pattern: []byte(`Host\x3a[^\r\n]*?\.tongji`),
+						Options: []byte("Hi"),
 					},
 				},
-				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
+				Tags: map[string]string{
+					"flow":      "to_server,established",
+					"classtype": "trojan-activity",
+				},
 				Metas: []*Metadata{
 					&Metadata{Key: "impact_flag", Value: "red"},
 					&Metadata{Key: "policy", Value: "balanced-ips drop"},
@@ -371,40 +597,73 @@ func TestParseRule(t *testing.T) {
 			name: "content and PCRE",
 			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"Foo msg"; flow:to_server,established; content:"blah"; http_uri; pcre:"/foo.*bar/Ui"; reference:url,www.google.com; classtype:trojan-activity; sid:12345; rev:1;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "tcp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"$HTTP_PORTS"}},
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"$HTTP_PORTS"},
+				},
 				SID:         12345,
 				Revision:    1,
 				Description: "Foo msg",
-				References:  []*Reference{&Reference{Type: "url", Value: "www.google.com"}},
+				References: []*Reference{
+					&Reference{
+						Type:  "url",
+						Value: "www.google.com"},
+				},
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x62, 0x6c, 0x61, 0x68}, Options: []*ContentOption{&ContentOption{"http_uri", 0}}},
+					&Content{
+						Pattern: []byte("blah"),
+						Options: []*ContentOption{
+							&ContentOption{"http_uri", 0},
+						},
+					},
 				},
 				PCREs: []*PCRE{
 					&PCRE{
-						Pattern: []byte{0x66, 0x6f, 0x6f, 0x2e, 0x2a, 0x62, 0x61, 0x72},
-						Options: []byte{0x55, 0x69}},
+						Pattern: []byte("foo.*bar"),
+						Options: []byte("Ui"),
+					},
 				},
-				Tags: map[string]string{"flow": "to_server,established", "classtype": "trojan-activity"},
+				Tags: map[string]string{
+					"flow":      "to_server,established",
+					"classtype": "trojan-activity",
+				},
 			},
 		},
 		{
 			name: "Metadata",
 			rule: `alert tcp any any -> any any (msg:"ET SHELLCODE Berlin Shellcode"; flow:established; content:"|31 c9 b1 fc 80 73 0c|"; content:"|43 e2 8b 9f|"; distance:0; reference:url,doc.emergingthreats.net/2009256; classtype:shellcode-detect; sid:2009256; rev:3; metadata:created_at 2010_07_30, updated_at 2010_07_30;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "tcp",
-				Source:      Network{Nets: []string{"any"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"any"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets: []string{"any"}, Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets: []string{"any"}, Ports: []string{"any"},
+				},
 				SID:         2009256,
 				Revision:    3,
 				Description: "ET SHELLCODE Berlin Shellcode",
-				References:  []*Reference{&Reference{Type: "url", Value: "doc.emergingthreats.net/2009256"}},
+				References: []*Reference{
+					&Reference{
+						Type:  "url",
+						Value: "doc.emergingthreats.net/2009256"},
+				},
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x31, 0xc9, 0xb1, 0xfc, 0x80, 0x73, 0x0c}},
-					&Content{Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f}, Options: []*ContentOption{&ContentOption{"distance", 0}}},
+					&Content{
+						Pattern: []byte{0x31, 0xc9, 0xb1, 0xfc, 0x80, 0x73, 0x0c},
+					},
+					&Content{
+						Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},
+						Options: []*ContentOption{
+							&ContentOption{"distance", 0},
+						},
+					},
 				},
 				Tags: map[string]string{"flow": "established", "classtype": "shellcode-detect"},
 				Metas: []*Metadata{
@@ -417,18 +676,49 @@ func TestParseRule(t *testing.T) {
 			name: "Multi Metadata",
 			rule: `alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"ET CURRENT_EVENTS Chase Account Phish Landing Oct 22"; flow:established,from_server; file_data; content:"<title>Sign in</title>"; content:"name=chalbhai"; fast_pattern; nocase; distance:0; content:"required title=|22|Please Enter Right Value|22|"; nocase; distance:0; content:"required title=|22|Please Enter Right Value|22|"; nocase; distance:0; metadata: former_category CURRENT_EVENTS; classtype:trojan-activity; sid:2025692; rev:2; metadata:created_at 2015_10_22, updated_at 2018_07_12;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "http",
-				Source:      Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
+				Action:   "alert",
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
 				SID:         2025692,
 				Revision:    2,
 				Description: "ET CURRENT_EVENTS Chase Account Phish Landing Oct 22",
 				Contents: []*Content{
-					&Content{Pattern: []byte{0x3c, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3e, 0x53, 0x69, 0x67, 0x6e, 0x20, 0x69, 0x6e, 0x3c, 0x2f, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3e}, DataPosition: 1, FastPattern: FastPattern{Enabled: false, Length: 0, Offset: 0}, Negate: false},
-					&Content{Pattern: []byte{0x6e, 0x61, 0x6d, 0x65, 0x3d, 0x63, 0x68, 0x61, 0x6c, 0x62, 0x68, 0x61, 0x69}, DataPosition: fileData, Options: []*ContentOption{&ContentOption{"nocase", 0}, &ContentOption{"distance", 0}}, FastPattern: FastPattern{Enabled: true, Length: 0, Offset: 0}, Negate: false},
-					&Content{Pattern: []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22}, DataPosition: fileData, Options: []*ContentOption{&ContentOption{"nocase", 0}, &ContentOption{"distance", 0}}, FastPattern: FastPattern{Enabled: false, Length: 0, Offset: 0}, Negate: false},
-					&Content{Pattern: []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22}, DataPosition: fileData, Options: []*ContentOption{&ContentOption{"nocase", 0}, &ContentOption{"distance", 0}}, FastPattern: FastPattern{Enabled: false, Length: 0, Offset: 0}, Negate: false},
+					&Content{
+						Pattern:      []byte("<title>Sign in</title>"),
+						DataPosition: fileData,
+					},
+					&Content{
+						Pattern:      []byte("name=chalbhai"),
+						DataPosition: fileData,
+						Options: []*ContentOption{
+							&ContentOption{"nocase", 0},
+							&ContentOption{"distance", 0},
+						},
+						FastPattern: FastPattern{Enabled: true},
+					},
+					&Content{
+						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
+						DataPosition: fileData,
+						Options: []*ContentOption{
+							&ContentOption{"nocase", 0},
+							&ContentOption{"distance", 0},
+						},
+					},
+					&Content{
+						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
+						DataPosition: fileData,
+						Options: []*ContentOption{
+							&ContentOption{"nocase", 0},
+							&ContentOption{"distance", 0},
+						},
+					},
 				},
 				Tags: map[string]string{"flow": "established,from_server", "classtype": "trojan-activity"},
 				Metas: []*Metadata{
@@ -442,18 +732,25 @@ func TestParseRule(t *testing.T) {
 			name: "Negated PCRE",
 			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"Negated PCRE"; pcre:!"/foo.*bar/Ui"; sid:12345; rev:1;)`,
 			want: &Rule{
-				Action:      "alert",
-				Protocol:    "tcp",
-				Source:      Network{Nets: []string{"$HOME_NET"}, Ports: []string{"any"}},
-				Destination: Network{Nets: []string{"$EXTERNAL_NET"}, Ports: []string{"$HTTP_PORTS"}},
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
 				SID:         12345,
 				Revision:    1,
 				Description: "Negated PCRE",
 				PCREs: []*PCRE{
 					&PCRE{
-						Pattern: []byte{0x66, 0x6f, 0x6f, 0x2e, 0x2a, 0x62, 0x61, 0x72},
+						Pattern: []byte("foo.*bar"),
 						Negate:  true,
-						Options: []byte{0x55, 0x69}},
+						Options: []byte("Ui"),
+					},
 				},
 			},
 		},

--- a/parser_test.go
+++ b/parser_test.go
@@ -15,10 +15,6 @@ limitations under the License.
 
 package gonids
 
-// TODO:
-//	Format long datas
-//	Make "byte" patterns more readable
-
 import (
 	"reflect"
 	"testing"


### PR DESCRIPTION
Clean up tests, add newlines for structs to add readability, use []byte("") with strings for better readability where feasible.

Closes #11 