### PR TITLE
loop instead of returning the same state and handle unexpected EOFs

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -296,13 +296,17 @@ func lexDestinationAddress(l *lexer) stateFn {
 
 // lexDestinationPort consumes a destination port.
 func lexDestinationPort(l *lexer) stateFn {
-	if l.next() == '(' {
-		l.backup()
-		l.emit(itemDestinationPort, true)
-		l.skipNext()
-		return lexOptionKey
+	for {
+		switch l.next() {
+		case '(':
+			l.backup()
+			l.emit(itemDestinationPort, true)
+			l.skipNext()
+			return lexOptionKey
+		case eof:
+			return l.unexpectedEOF()
+		}
 	}
-	return lexDestinationPort
 }
 
 // lexOptionKey scans a key from the rule options.

--- a/lex.go
+++ b/lex.go
@@ -283,11 +283,15 @@ func lexDirection(l *lexer) stateFn {
 
 // lexDestinationAddress consumes a destination address.
 func lexDestinationAddress(l *lexer) stateFn {
-	if l.next() == ' ' {
-		l.emit(itemDestinationAddress, true)
-		return lexDestinationPort
+	for {
+		switch l.next() {
+		case ' ':
+			l.emit(itemDestinationAddress, true)
+			return lexDestinationPort
+		case eof:
+			return l.unexpectedEOF()
+		}
 	}
-	return lexDestinationAddress
 }
 
 // lexDestinationPort consumes a destination port.

--- a/lex.go
+++ b/lex.go
@@ -352,19 +352,22 @@ func lexOptionValueString(l *lexer) stateFn {
 
 // lexOptionValue scans a value from the rule options.
 func lexOptionValue(l *lexer) stateFn {
-	switch l.next() {
-	case ';':
-		l.backup()
-		l.emit(itemOptionValue, true)
-		l.skipNext()
-		return lexOptionKey
-	case ')':
-		l.backup()
-		l.emit(itemOptionValue, true)
-		l.skipNext()
-		return lexRuleEnd
+	for {
+		switch l.next() {
+		case ';':
+			l.backup()
+			l.emit(itemOptionValue, true)
+			l.skipNext()
+			return lexOptionKey
+		case ')':
+			l.backup()
+			l.emit(itemOptionValue, true)
+			l.skipNext()
+			return lexRuleEnd
+		case eof:
+			return l.unexpectedEOF()
+		}
 	}
-	return lexOptionValue
 }
 
 // lexOptionEnd marks the end of a rule.

--- a/lex.go
+++ b/lex.go
@@ -260,11 +260,15 @@ func lexSourceAddress(l *lexer) stateFn {
 
 // lexSourcePort consumes a source port.
 func lexSourcePort(l *lexer) stateFn {
-	if l.next() == ' ' {
-		l.emit(itemSourcePort, true)
-		return lexDirection
+	for {
+		switch l.next() {
+		case ' ':
+			l.emit(itemSourcePort, true)
+			return lexDirection
+		case eof:
+			return l.unexpectedEOF()
+		}
 	}
-	return lexSourcePort
 }
 
 // lexDirection consumes a rule direction.

--- a/lex.go
+++ b/lex.go
@@ -294,29 +294,32 @@ func lexDestinationPort(l *lexer) stateFn {
 
 // lexOptionKey scans a key from the rule options.
 func lexOptionKey(l *lexer) stateFn {
-	switch l.next() {
-	case ':':
-		l.backup()
-		l.emit(itemOptionKey, true)
-		l.skipNext()
-		return lexOptionValueBegin
-	case ';':
-		l.backup()
-		if l.pos > l.start {
+	for {
+		switch l.next() {
+		case ':':
+			l.backup()
 			l.emit(itemOptionKey, true)
-			l.emit(itemOptionNoValue, true)
+			l.skipNext()
+			return lexOptionValueBegin
+		case ';':
+			l.backup()
+			if l.pos > l.start {
+				l.emit(itemOptionKey, true)
+				l.emit(itemOptionNoValue, true)
+			}
+			l.skipNext()
+			return lexOptionKey
+		case ')':
+			l.backup()
+			if l.pos > l.start {
+				l.emit(itemOptionKey, true)
+			}
+			l.skipNext()
+			return lexRuleEnd
+		case eof:
+			return l.unexpectedEOF()
 		}
-		l.skipNext()
-		return lexOptionKey
-	case ')':
-		l.backup()
-		if l.pos > l.start {
-			l.emit(itemOptionKey, true)
-		}
-		l.skipNext()
-		return lexRuleEnd
 	}
-	return lexOptionKey
 }
 
 // lexOptionValueBegin scans the beginning of a value from the rule option.

--- a/lex.go
+++ b/lex.go
@@ -206,16 +206,17 @@ func lexRule(l *lexer) stateFn {
 
 // lexComment consumes a commented rule.
 func lexComment(l *lexer) stateFn {
-	switch l.next() {
-	case '\n':
-		l.emit(itemComment, false)
-		return lexRule
-	case eof:
-		l.backup()
-		l.emit(itemComment, false)
-		return lexRule
+	for {
+		switch l.next() {
+		case '\n':
+			l.emit(itemComment, false)
+			return lexRule
+		case eof:
+			l.backup()
+			l.emit(itemComment, false)
+			return lexRule
+		}
 	}
-	return lexComment
 }
 
 // lexAction consumes a rule action.

--- a/lex.go
+++ b/lex.go
@@ -247,11 +247,15 @@ func lexProtocol(l *lexer) stateFn {
 
 // lexSourceAddress consumes a source address.
 func lexSourceAddress(l *lexer) stateFn {
-	if l.next() == ' ' {
-		l.emit(itemSourceAddress, true)
-		return lexSourcePort
+	for {
+		switch l.next() {
+		case ' ':
+			l.emit(itemSourceAddress, true)
+			return lexSourcePort
+		case eof:
+			return l.unexpectedEOF()
+		}
 	}
-	return lexSourceAddress
 }
 
 // lexSourcePort consumes a source port.

--- a/lex.go
+++ b/lex.go
@@ -332,13 +332,14 @@ func lexOptionValueBegin(l *lexer) stateFn {
 
 // lexOptionValueString consumes the inner content of a string value from the rule options.
 func lexOptionValueString(l *lexer) stateFn {
-	if l.next() == '"' {
-		l.backup()
-		l.emit(itemOptionValueString, false)
-		l.skipNext()
-		return lexOptionKey
+	for {
+		if l.next() == '"' {
+			l.backup()
+			l.emit(itemOptionValueString, false)
+			l.skipNext()
+			return lexOptionKey
+		}
 	}
-	return lexOptionValueString
 }
 
 // lexOptionValue scans a value from the rule options.

--- a/lex_test.go
+++ b/lex_test.go
@@ -154,6 +154,11 @@ func TestLexer(t *testing.T) {
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (key1:\"incomplet",
 			wantErr: true,
 		},
+		{
+			name:    "value EOF",
+			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (key1:incomplet",
+			wantErr: true,
+		},
 	} {
 		lexItems, err := collect(tt.input)
 		if (err != nil) != tt.wantErr {

--- a/lex_test.go
+++ b/lex_test.go
@@ -160,6 +160,11 @@ func TestLexer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "destination address EOF",
+			input:   "alert udp $HOME_NET any -> incomplet",
+			wantErr: true,
+		},
+		{
 			name:    "option key EOF",
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (incomplet",
 			wantErr: true,

--- a/lex_test.go
+++ b/lex_test.go
@@ -150,6 +150,11 @@ func TestLexer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "option key EOF",
+			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (incomplet",
+			wantErr: true,
+		},
+		{
 			name:    "value string EOF",
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (key1:\"incomplet",
 			wantErr: true,

--- a/lex_test.go
+++ b/lex_test.go
@@ -165,6 +165,11 @@ func TestLexer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "destination port EOF",
+			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET incomplet",
+			wantErr: true,
+		},
+		{
 			name:    "option key EOF",
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (incomplet",
 			wantErr: true,

--- a/lex_test.go
+++ b/lex_test.go
@@ -155,6 +155,11 @@ func TestLexer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "source port EOF",
+			input:   "alert udp $HOME_NET incomplet",
+			wantErr: true,
+		},
+		{
 			name:    "option key EOF",
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (incomplet",
 			wantErr: true,

--- a/lex_test.go
+++ b/lex_test.go
@@ -149,6 +149,11 @@ func TestLexer(t *testing.T) {
 			input:   "alert udp $HOME_NET any foo any any (key);",
 			wantErr: true,
 		},
+		{
+			name:    "value string EOF",
+			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (key1:\"incomplet",
+			wantErr: true,
+		},
 	} {
 		lexItems, err := collect(tt.input)
 		if (err != nil) != tt.wantErr {

--- a/lex_test.go
+++ b/lex_test.go
@@ -150,6 +150,11 @@ func TestLexer(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "source address EOF",
+			input:   "alert udp incomplet",
+			wantErr: true,
+		},
+		{
 			name:    "option key EOF",
 			input:   "alert udp $HOME_NET any -> $EXTERNAL_NET any (incomplet",
 			wantErr: true,


### PR DESCRIPTION
This PR makes two changes:
1. It fixes a family of bugs where the lexer would loop forever (via the same function calls) when an unexpected EOF is encountered
2. Instead of returning the same state again, loop explicitly and thus avoid some overhead e.g. for function calls