### PR TITLE
fix lexing of escaped quote signs

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -389,7 +389,6 @@ func lexOptionValueString(l *lexer) stateFn {
 			l.skipNext()
 			return lexOptionKey
 		case '\\':
-			// TODO: this should probably remove the escape character
 			if l.next() != '"' {
 				l.backup()
 			}

--- a/lex.go
+++ b/lex.go
@@ -388,6 +388,11 @@ func lexOptionValueString(l *lexer) stateFn {
 			l.emit(itemOptionValueString, false)
 			l.skipNext()
 			return lexOptionKey
+		case '\\':
+			// TODO: this should probably remove the escape character
+			if l.next() != '"' {
+				l.backup()
+			}
 		case eof:
 			return l.unexpectedEOF()
 		}

--- a/lex_test.go
+++ b/lex_test.go
@@ -148,6 +148,22 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
+			name:  "escaped quote",
+			input: `alert udp $HOME_NET any -> $EXTERNAL_NET any (pcre:"/[=\"]\w{8}\.jar/Hi";) ;`,
+			items: []item{
+				{itemAction, "alert"},
+				{itemProtocol, "udp"},
+				{itemSourceAddress, "$HOME_NET"},
+				{itemSourcePort, "any"},
+				{itemDirection, "->"},
+				{itemDestinationAddress, "$EXTERNAL_NET"},
+				{itemDestinationPort, "any"},
+				{itemOptionKey, "pcre"},
+				{itemOptionValueString, `/[=\"]\w{8}\.jar/Hi`},
+				{itemEOR, ""},
+			},
+		},
+		{
 			name:  "comment",
 			input: "# bla",
 			items: []item{{itemComment, "# bla"}},

--- a/parser.go
+++ b/parser.go
@@ -75,6 +75,13 @@ func parsePCRE(s string) (*PCRE, error) {
 	}, nil
 }
 
+func unquote(s string) string {
+	if strings.IndexByte(s, '"') < 0 {
+		return s
+	}
+	return strings.Replace(s, `\"`, `"`, -1)
+}
+
 func inSlice(str string, strings []string) bool {
 	for _, k := range strings {
 		if str == k {
@@ -324,7 +331,7 @@ func (r *Rule) option(key item, l *lexer) error {
 			negate = true
 		}
 		if nextItem.typ == itemOptionValueString {
-			p, err := parsePCRE(nextItem.value)
+			p, err := parsePCRE(unquote(nextItem.value))
 			if err != nil {
 				return err
 			}

--- a/parser_test.go
+++ b/parser_test.go
@@ -679,6 +679,31 @@ func TestParseRule(t *testing.T) {
 			},
 		},
 		{
+			name: "PCRE with quote",
+			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET $HTTP_PORTS (msg:"PCRE with quote"; pcre:"/=[.\"]\w{8}\.jar/Hi"; sid:12345; rev:1;)`,
+			want: &Rule{
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				SID:         12345,
+				Revision:    1,
+				Description: "PCRE with quote",
+				PCREs: []*PCRE{
+					&PCRE{
+						Pattern: []byte(`=[."]\w{8}\.jar`),
+						Options: []byte("Hi"),
+					},
+				},
+			},
+		},
+		{
 			name: "byte_extract",
 			rule: `alert tcp $EXTERNAL_NET 443 -> $HOME_NET any (msg:"byte_extract"; content:"|ff fe|"; byte_extract:3,0,Certs.len, relative ,little ; content:"|55 04 0a 0c 0C|"; distance:3; within:Certs.len; sid:42; rev:1;)`,
 			want: &Rule{

--- a/rule.go
+++ b/rule.go
@@ -376,15 +376,22 @@ func (ms Metadatas) String() string {
 
 // String returns a string for a PCRE.
 func (p PCRE) String() string {
-	if len(p.Pattern) < 1 {
+	pattern := p.Pattern
+	if len(pattern) < 1 {
 		return ""
 	}
+
+	// escape quote signs, if necessary
+	if bytes.IndexByte(pattern, '"') > -1 {
+		pattern = bytes.Replace(pattern, []byte(`"`), []byte(`\"`), -1)
+	}
+
 	var s strings.Builder
 	s.WriteString("pcre:")
 	if p.Negate {
 		s.WriteString("!")
 	}
-	s.WriteString(fmt.Sprintf(`"/%s/%s";`, p.Pattern, p.Options))
+	s.WriteString(fmt.Sprintf(`"/%s/%s";`, pattern, p.Options))
 	return s.String()
 }
 


### PR DESCRIPTION
According to https://suricata.readthedocs.io/en/suricata-4.1.3/rules/intro.html#rule-options option values may contain `"` characters which then must be escaped using backslashes, e.g. `"string containing a \" character"`.

The lexer currently can not handle those correctly.
This PR is not a full solution to the problem yet as I would like to discuss which approach to take first.
As I see it, there are two options:

1. Do some hacky stuff to remove the escape character from the input buffer
2. Post-process the value. One could either set some flag and call some function on the string value when needed (my preferred approach) or leave it to the parser.

What do you think?