### PR TITLE
handle extra spaces in header correctly

### DIFF
--- a/lex_test.go
+++ b/lex_test.go
@@ -112,7 +112,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "multiple spaces",
-			input: "\talert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1: value1 ; key2;) ;",
+			input: "\talert   udp   $HOME_NET   any   ->   [1.1.1.1,2.2.2.2]   any   (key1: value1 ; key2;) ;",
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},


### PR DESCRIPTION
Rules e.g. from Emerging Threats sometimes contain extra spaces in the header and currently can not be parsed correctly.
With this PR extra spaces before any header value are removed.