### PR TITLE
fix lexing of values containing parentheses

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -379,11 +379,6 @@ func lexOptionValue(l *lexer) stateFn {
 			l.emit(itemOptionValue, true)
 			l.skipNext()
 			return lexOptionKey
-		case ')':
-			l.backup()
-			l.emit(itemOptionValue, true)
-			l.skipNext()
-			return lexRuleEnd
 		case eof:
 			return l.unexpectedEOF()
 		}

--- a/lex_test.go
+++ b/lex_test.go
@@ -46,7 +46,7 @@ func TestLexer(t *testing.T) {
 	}{
 		{
 			name:  "simple",
-			input: "alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:value1; key2:value2);",
+			input: "alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:value1; key2:value2;);",
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -64,7 +64,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "string value",
-			input: `alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:"value1");`,
+			input: `alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:"value1";);`,
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -80,7 +80,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "string value not",
-			input: `alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:!"value1");`,
+			input: `alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:!"value1";);`,
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -97,7 +97,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "single key",
-			input: "alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key);",
+			input: "alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key;);",
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -107,6 +107,7 @@ func TestLexer(t *testing.T) {
 				{itemDestinationAddress, "[1.1.1.1,2.2.2.2]"},
 				{itemDestinationPort, "any"},
 				{itemOptionKey, "key"},
+				{itemOptionNoValue, ""},
 				{itemEOR, ""},
 			},
 		},
@@ -125,6 +126,24 @@ func TestLexer(t *testing.T) {
 				{itemOptionValue, "value1"},
 				{itemOptionKey, "key2"},
 				{itemOptionNoValue, ""},
+				{itemEOR, ""},
+			},
+		},
+		{
+			name:  "parentheses in value",
+			input: `alert dns $HOME_NET any -> any any (reference:url,en.wikipedia.org/wiki/Tor_(anonymity_network); sid:42;) ;`,
+			items: []item{
+				{itemAction, "alert"},
+				{itemProtocol, "dns"},
+				{itemSourceAddress, "$HOME_NET"},
+				{itemSourcePort, "any"},
+				{itemDirection, "->"},
+				{itemDestinationAddress, "any"},
+				{itemDestinationPort, "any"},
+				{itemOptionKey, "reference"},
+				{itemOptionValue, "url,en.wikipedia.org/wiki/Tor_(anonymity_network)"},
+				{itemOptionKey, "sid"},
+				{itemOptionValue, "42"},
 				{itemEOR, ""},
 			},
 		},

--- a/parser_test.go
+++ b/parser_test.go
@@ -66,7 +66,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "simple content",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -90,7 +90,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "commented rule content",
-			rule: `#alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
+			rule: `#alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2;);`,
 			want: &Rule{
 				Disabled: true,
 				Action:   "alert",
@@ -115,7 +115,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "bidirectional",
-			rule: `alert udp $HOME_NET any <> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2);`,
+			rule: `alert udp $HOME_NET any <> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; rev:2;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -140,7 +140,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "not content",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA");`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA";);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -162,7 +162,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "multiple contents",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; content:"BB");`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"AA"; content:"BB";);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -188,7 +188,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "hex content",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A|42 43|D|45|");`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A|42 43|D|45|";);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -211,7 +211,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "tags",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; classtype:foo);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; classtype:foo;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -234,7 +234,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "references",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A"; reference:cve,2014; reference:url,www.suricata-ids.org);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"A"; reference:cve,2014; reference:url,www.suricata-ids.org;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -261,7 +261,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "content options",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; http_header; offset:3);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:!"AA"; http_header; offset:3;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -289,7 +289,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "multiple contents and options",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern; content:"B"; http_uri);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern; content:"B"; http_uri;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -322,7 +322,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "multiple contents and multiple options",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern:0,42; nocase; content:"B"; http_uri);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; content:"A"; http_header; fast_pattern:0,42; nocase; content:"B"; http_uri;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -356,7 +356,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "multiple contents with file_data",
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; file_data; content:"A"; http_header; nocase; content:"B"; http_uri);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; msg:"a"; file_data; content:"A"; http_header; nocase; content:"B"; http_uri;);`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "udp",
@@ -681,7 +681,7 @@ func TestParseRule(t *testing.T) {
 		// Errors
 		{
 			name:    "invalid direction",
-			rule:    `alert udp $HOME_NET any *# $EXTERNAL_NET any (sid:2; msg:"foo"; content:"A");`,
+			rule:    `alert udp $HOME_NET any *# $EXTERNAL_NET any (sid:2; msg:"foo"; content:"A";);`,
 			wantErr: true,
 		},
 		{
@@ -691,17 +691,17 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name:    "invalid content option",
-			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; content:"foo"; offset:"a");`,
+			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; content:"foo"; offset:"a";);`,
 			wantErr: true,
 		},
 		{
 			name:    "invalid content value",
-			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; content:!; offset:"a");`,
+			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1; content:!; offset:"a";);`,
 			wantErr: true,
 		},
 		{
 			name:    "invalid msg",
-			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:2; msg; content:"A");`,
+			rule:    `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:2; msg; content:"A";);`,
 			wantErr: true,
 		},
 	} {
@@ -744,14 +744,17 @@ func TestInEqualOut(t *testing.T) {
 	}{
 		{
 			name:  "simple test",
-			input: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"|28|foo"; content:".AA"; within:40);`,
+			input: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"|28|foo"; content:".AA"; within:40;);`,
 		},
 		{
 			name:  "complex rule",
 			input: `alert http $EXTERNAL_NET any -> $HOME_NET any (msg:"FOO BAR BLAH"; flow:established,from_server; content:"200"; http_stat_code; file_data; content:"|3d 21 2d 2f|eyJjWEEEEEE"; fast_pattern; content:"|3z 21 2f 2d|"; pcre:"/^(?:[A-Z0-9+/]{1})*(?:[A-Z0-9+/]{1}==|[A-Z0-9+/]{7}=|[A-Z0-9+/]{9})/R"; metadata: former_category BOO; reference:url,this.is.sparta.com/fooblog; classtype:trojan-activity; sid:1111111; rev:1; metadata:affected_product Windows_XP_Vista_7_8_10_Server_32_64_Bit, attack_target Client_Endpoint, deployment Perimeter, tag FOOO, signature_severity Major, created_at 2018_06_25, performance_impact Low, updated_at 2018_09_23;)`,
 		},
 	} {
-		first, _ := ParseRule(tt.input)
+		first, err := ParseRule(tt.input)
+		if err != nil {
+			t.Fatalf("%v", err)
+		}
 		s := first.String()
 		second, err := ParseRule(s)
 		if err != nil {

--- a/rule_test.go
+++ b/rule_test.go
@@ -631,7 +631,7 @@ func TestRE(t *testing.T) {
 		want string
 	}{
 		{
-			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"|28|foo"; content:".AA"; within:40);`,
+			rule: `alert udp $HOME_NET any -> $EXTERNAL_NET any (sid:1337; msg:"foo"; content:"|28|foo"; content:".AA"; within:40;);`,
 			want: `.*\(foo.{0,40}\.AA`,
 		},
 	} {


### PR DESCRIPTION
It seems that ever option MUST be terminated with a `;`.
With that one can also correctly parse values containing `)`, which is e.g. sometimes the case in reference URLs (see test). 