### PR TITLE
add support for arbitrary byte_extract options

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -339,19 +339,11 @@ func (r *Rule) option(key item, l *lexer) error {
 		}
 		nextItem := l.nextItem()
 		parts := strings.Split(nextItem.value, ",")
-		v := new(Var)
-		switch len(parts) {
-		case 4:
-			parts[3] = strings.TrimSpace(parts[3])
-			if parts[3] != "relative" {
-				return fmt.Errorf("invalid byte_extract option: %s", parts[3])
-			}
-			v.Relative = true
-		case 3:
-			// no extra options
-		default:
+		if len(parts) < 3 {
 			return fmt.Errorf("invalid byte_extract value: %s", nextItem.value)
 		}
+
+		v := new(Var)
 
 		n, err := strconv.Atoi(parts[0])
 		if err != nil {
@@ -372,6 +364,13 @@ func (r *Rule) option(key item, l *lexer) error {
 		} else if _, exists := r.Vars[name]; exists {
 			return fmt.Errorf("byte_extract var already declared: %s", name)
 		}
+
+		// options
+		for i, l := 3, len(parts); i < l; i++ {
+			parts[i] = strings.TrimSpace(parts[i])
+			v.Options = append(v.Options, parts[i])
+		}
+
 		r.Vars[name] = v
 		lastContent := r.Contents[len(r.Contents)-1]
 		lastContent.Options = append(lastContent.Options, &ContentOption{Name: key.value, Value: strings.Join(parts, ",")})

--- a/parser_test.go
+++ b/parser_test.go
@@ -680,7 +680,7 @@ func TestParseRule(t *testing.T) {
 		},
 		{
 			name: "byte_extract",
-			rule: `alert tcp $EXTERNAL_NET 443 -> $HOME_NET any (msg:"byte_extract"; content:"|ff fe|"; byte_extract:3,0,Certs.len, relative; content:"|55 04 0a 0c 0C|"; distance:3; within:Certs.len; sid:42; rev:1;)`,
+			rule: `alert tcp $EXTERNAL_NET 443 -> $HOME_NET any (msg:"byte_extract"; content:"|ff fe|"; byte_extract:3,0,Certs.len, relative ,little ; content:"|55 04 0a 0c 0C|"; distance:3; within:Certs.len; sid:42; rev:1;)`,
 			want: &Rule{
 				Action:   "alert",
 				Protocol: "tcp",
@@ -700,7 +700,7 @@ func TestParseRule(t *testing.T) {
 						Pattern:      []byte{0xff, 0xfe},
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"byte_extract", "3,0,Certs.len,relative"},
+							&ContentOption{"byte_extract", "3,0,Certs.len,relative,little"},
 						},
 					},
 					&Content{
@@ -713,7 +713,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				Vars: map[string]*Var{
-					"Certs.len": {3, 0, true},
+					"Certs.len": {3, 0, []string{"relative", "little"}},
 				},
 			},
 		},

--- a/rule.go
+++ b/rule.go
@@ -68,7 +68,7 @@ type Rule struct {
 type Var struct {
 	NumBytes int
 	Offset   int
-	Relative bool
+	Options  []string
 }
 
 // Metadata describes metadata tags in key-value struct.


### PR DESCRIPTION
Turns out that `byte_extract` supports more options than explained in the documentation. `little` (endianness) seems to be another popular one.