### PR TITLE
allow protocols to contain '-'

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -109,6 +109,14 @@ func (l *lexer) peek() rune {
 	return r
 }
 
+// len returns the the current length of the item in processing.
+func (l *lexer) len() int {
+	if l.pos >= len(l.input) {
+		return -1
+	}
+	return l.pos - l.start
+}
+
 // backup steps back one rune. Can only be called once per call of next.
 func (l *lexer) backup() {
 	if l.width == -1 {
@@ -229,15 +237,16 @@ func lexComment(l *lexer) stateFn {
 
 // lexAction consumes a rule action.
 func lexAction(l *lexer) stateFn {
-	r := l.next()
-	switch {
-	case r == ' ':
-		l.emit(itemAction, true)
-		return lexProtocol
-	case unicode.IsLetter(r):
-		return lexAction
+	for {
+		r := l.next()
+		switch {
+		case r == ' ':
+			l.emit(itemAction, true)
+			return lexProtocol
+		case !unicode.IsLetter(r):
+			return l.errorf("invalid character %q for a rule action", r)
+		}
 	}
-	return l.errorf("invalid character %q for a rule action", r)
 }
 
 // lexProtocol consumes a rule protocol.
@@ -249,7 +258,7 @@ func lexProtocol(l *lexer) stateFn {
 		case r == ' ':
 			l.emit(itemProtocol, true)
 			return lexSourceAddress
-		case !unicode.IsLetter(r):
+		case !(unicode.IsLetter(r) || (l.len() > 0 && r == '-')):
 			return l.errorf("invalid character %q for a rule protocol", r)
 		}
 	}

--- a/lex_test.go
+++ b/lex_test.go
@@ -64,10 +64,10 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "string value",
-			input: `alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:"value1";)`,
+			input: `alert tcp-pkt $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key1:"value1";)`,
 			items: []item{
 				{itemAction, "alert"},
-				{itemProtocol, "udp"},
+				{itemProtocol, "tcp-pkt"},
 				{itemSourceAddress, "$HOME_NET"},
 				{itemSourcePort, "any"},
 				{itemDirection, "->"},


### PR DESCRIPTION
The lexer currently does not allow protocol names to contain '-'.
However, `tcp-pkt` and `tcp-stream` are valid protocol names in Suricata: https://github.com/OISF/suricata/blob/master/doc/userguide/rules/differences-from-snort.rst#dont-cross-the-streams