### PR TITLE
do not unescape quote if backslash is escaped

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -381,6 +381,7 @@ func lexOptionValueBegin(l *lexer) stateFn {
 
 // lexOptionValueString consumes the inner content of a string value from the rule options.
 func lexOptionValueString(l *lexer) stateFn {
+	escaped := false
 	for {
 		switch l.next() {
 		case '"':
@@ -389,11 +390,14 @@ func lexOptionValueString(l *lexer) stateFn {
 			l.skipNext()
 			return lexOptionKey
 		case '\\':
-			if l.next() != '"' {
+			escaped = !escaped
+			if l.next() != '"' || !escaped {
 				l.backup()
 			}
 		case eof:
 			return l.unexpectedEOF()
+		default:
+			escaped = false
 		}
 	}
 }

--- a/lex_test.go
+++ b/lex_test.go
@@ -113,7 +113,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "multiple spaces",
-			input: "\talert   udp   $HOME_NET   any   ->   [1.1.1.1,2.2.2.2]   any   (key1: value1 ; key2;) ;",
+			input: "\talert   udp   $HOME_NET   any   ->   [1.1.1.1,2.2.2.2]   any   (key1: value1 ; key2;)",
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -131,7 +131,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "parentheses in value",
-			input: `alert dns $HOME_NET any -> any any (reference:url,en.wikipedia.org/wiki/Tor_(anonymity_network); sid:42;) ;`,
+			input: `alert dns $HOME_NET any -> any any (reference:url,en.wikipedia.org/wiki/Tor_(anonymity_network); sid:42;)`,
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "dns"},
@@ -149,7 +149,7 @@ func TestLexer(t *testing.T) {
 		},
 		{
 			name:  "escaped quote",
-			input: `alert udp $HOME_NET any -> $EXTERNAL_NET any (pcre:"/[=\"]\w{8}\.jar/Hi";) ;`,
+			input: `alert udp $HOME_NET any -> $EXTERNAL_NET any (pcre:"/[=\"]\w{8}\.jar/Hi";)`,
 			items: []item{
 				{itemAction, "alert"},
 				{itemProtocol, "udp"},
@@ -160,6 +160,24 @@ func TestLexer(t *testing.T) {
 				{itemDestinationPort, "any"},
 				{itemOptionKey, "pcre"},
 				{itemOptionValueString, `/[=\"]\w{8}\.jar/Hi`},
+				{itemEOR, ""},
+			},
+		},
+		{
+			name:  "escaped backslash",
+			input: `alert tcp $HOME_NET any -> $EXTERNAL_NET 21 (content:"CWD C|3a|\\WINDOWS\\system32\\"; sid:42;)`,
+			items: []item{
+				{itemAction, "alert"},
+				{itemProtocol, "tcp"},
+				{itemSourceAddress, "$HOME_NET"},
+				{itemSourcePort, "any"},
+				{itemDirection, "->"},
+				{itemDestinationAddress, "$EXTERNAL_NET"},
+				{itemDestinationPort, "21"},
+				{itemOptionKey, "content"},
+				{itemOptionValueString, `CWD C|3a|\\WINDOWS\\system32\\`},
+				{itemOptionKey, "sid"},
+				{itemOptionValue, "42"},
 				{itemEOR, ""},
 			},
 		},

--- a/rule_test.go
+++ b/rule_test.go
@@ -84,6 +84,13 @@ func TestContentFormatPattern(t *testing.T) {
 			},
 			want: "abcd|3B 3A 0D 0A|e|0D|f",
 		},
+		{
+			name: "double backslash",
+			input: &Content{
+				Pattern: []byte(`C|3a|\\WINDOWS\\system32\\`),
+			},
+			want: `C|3a|\\WINDOWS\\system32\\`,
+		},
 	} {
 		got := tt.input.FormatPattern()
 		if !reflect.DeepEqual(got, tt.want) {


### PR DESCRIPTION
It's getting more complicated... 
Now `content:"CWD C|3a|\\WINDOWS\\system32\\"` is not lexed properly.

The next question is: should the value be `CWD C|3a|\\WINDOWS\\system32\\` or should `\\` be replaced with `\`, i.e. `CWD C|3a|\WINDOWS\system32\`?