### PR TITLE
export StickyBuffer()

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -236,7 +236,7 @@ func (r *Rule) option(key item, l *lexer) error {
 	case isStickyBuffer(key.value):
 		var d dataPos
 		var err error
-		if d, err = stickyBuffer(key.value); err != nil {
+		if d, err = StickyBuffer(key.value); err != nil {
 			return err
 		}
 		dataPosition = d

--- a/rule.go
+++ b/rule.go
@@ -171,7 +171,8 @@ func (d dataPos) String() string {
 	return stickyBuffers[d]
 }
 
-func stickyBuffer(s string) (dataPos, error) {
+// StickyBuffer returns the data position value for the string representation of a sticky buffer name (e.g. "file_data")
+func StickyBuffer(s string) (dataPos, error) {
 	for k, v := range stickyBuffers {
 		if v == s {
 			return k, nil
@@ -181,7 +182,7 @@ func stickyBuffer(s string) (dataPos, error) {
 }
 
 func isStickyBuffer(s string) bool {
-	_, err := stickyBuffer(s)
+	_, err := StickyBuffer(s)
 	return err == nil
 }
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -724,7 +724,7 @@ func TestStickyBuffer(t *testing.T) {
 			wantErr: false,
 		},
 	} {
-		got, gotErr := stickyBuffer(tt.s)
+		got, gotErr := StickyBuffer(tt.s)
 		if got != tt.want {
 			t.Fatalf("got=%v; want=%v", got, tt.want)
 		}


### PR DESCRIPTION
### Changes
* Export `StickyBuffer()` to make it easier for libraries to access the data position values for sticky buffers via the buffer name.