### PR TITLE
Lex until ';' instead of '"'

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -133,6 +133,7 @@ func (l *lexer) emit(t itemType, trimSpaces bool) {
 	if trimSpaces {
 		input = strings.TrimSpace(input)
 	}
+
 	// This is a bit of a hack. We lex until `;` now so we end up with extra `"`.
 	input = strings.TrimSuffix(input, `"`)
 	l.items <- item{t, input}

--- a/lex.go
+++ b/lex.go
@@ -389,8 +389,6 @@ func lexOptionValueString(l *lexer) stateFn {
 		switch l.next() {
 		case ';':
 			l.backup()
-			if escaped {
-			}
 			l.emit(itemOptionValueString, false)
 			l.skipNext()
 			return lexOptionKey

--- a/lex.go
+++ b/lex.go
@@ -133,6 +133,8 @@ func (l *lexer) emit(t itemType, trimSpaces bool) {
 	if trimSpaces {
 		input = strings.TrimSpace(input)
 	}
+	// This is a bit of a hack. We lex until `;` now so we end up with extra `"`.
+	input = strings.TrimSuffix(input, `"`)
 	l.items <- item{t, input}
 	l.start = l.pos
 }
@@ -384,14 +386,16 @@ func lexOptionValueString(l *lexer) stateFn {
 	escaped := false
 	for {
 		switch l.next() {
-		case '"':
+		case ';':
 			l.backup()
+			if escaped {
+			}
 			l.emit(itemOptionValueString, false)
 			l.skipNext()
 			return lexOptionKey
 		case '\\':
 			escaped = !escaped
-			if l.next() != '"' || !escaped {
+			if l.next() != ';' || !escaped {
 				l.backup()
 			}
 		case eof:

--- a/parser.go
+++ b/parser.go
@@ -40,8 +40,7 @@ var metaSplitRE = regexp.MustCompile(`,\s*`)
 // parseContent decodes rule content match. For now it only takes care of escaped and hex
 // encoded content.
 func parseContent(content string) ([]byte, error) {
-	// Unescape, decode and replace all occurrences of hexadecimal content.
-	// b := hexRE.ReplaceAllStringFunc(strings.Replace(content, `\`, "", -1),
+	// Decode and replace all occurrences of hexadecimal content.
 	b := hexRE.ReplaceAllStringFunc(content,
 		func(h string) string {
 			r, err := hex.DecodeString(strings.Replace(strings.Trim(h, "|"), " ", "", -1))

--- a/parser.go
+++ b/parser.go
@@ -41,7 +41,8 @@ var metaSplitRE = regexp.MustCompile(`,\s*`)
 // encoded content.
 func parseContent(content string) ([]byte, error) {
 	// Unescape, decode and replace all occurrences of hexadecimal content.
-	b := hexRE.ReplaceAllStringFunc(strings.Replace(content, `\`, "", -1),
+	// b := hexRE.ReplaceAllStringFunc(strings.Replace(content, `\`, "", -1),
+	b := hexRE.ReplaceAllStringFunc(content,
 		func(h string) string {
 			r, err := hex.DecodeString(strings.Replace(strings.Trim(h, "|"), " ", "", -1))
 			if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,11 +35,6 @@ func TestParseContent(t *testing.T) {
 			want:  []byte("abcd"),
 		},
 		{
-			name:  "escaped content",
-			input: `abcd\;ef`,
-			want:  []byte("abcd;ef"),
-		},
-		{
 			name:  "hex content",
 			input: "A|42 43|D| 45|",
 			want:  []byte("ABCDE"),
@@ -792,6 +787,29 @@ func TestParseRule(t *testing.T) {
 				},
 				Vars: map[string]*Var{
 					"Certs.len": {3, 0, []string{"relative", "little"}},
+				},
+			},
+		},
+		{
+			name: "content with backslash at end",
+			rule: `alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"ending backslash rule"; content:"foo\"; sid:12345; rev:2;)`, want: &Rule{
+				Action:   "alert",
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
+				SID:         12345,
+				Revision:    2,
+				Description: "ending backslash rule",
+				Contents: Contents{
+					&Content{
+						Pattern: []byte{0x66, 0x6f, 0x6f, 0x5c},
+					},
 				},
 			},
 		},

--- a/rule_test.go
+++ b/rule_test.go
@@ -281,6 +281,11 @@ func TestNetString(t *testing.T) {
 			input: []string{"$HOME_NET", "!$FOO_NET", "192.168.0.0/16"},
 			want:  "[$HOME_NET, !$FOO_NET, 192.168.0.0/16]",
 		},
+		{
+			name:  "busted",
+			input: []string{"82.163.143.135", "82.163.142.137"},
+			want:  "[82.163.143.135, 82.163.142.137]",
+		},
 	} {
 		got := netString(tt.input)
 		if got != tt.want {

--- a/rule_test.go
+++ b/rule_test.go
@@ -281,11 +281,6 @@ func TestNetString(t *testing.T) {
 			input: []string{"$HOME_NET", "!$FOO_NET", "192.168.0.0/16"},
 			want:  "[$HOME_NET, !$FOO_NET, 192.168.0.0/16]",
 		},
-		{
-			name:  "busted",
-			input: []string{"82.163.143.135", "82.163.142.137"},
-			want:  "[82.163.143.135, 82.163.142.137]",
-		},
 	} {
 		got := netString(tt.input)
 		if got != tt.want {


### PR DESCRIPTION
Lex until ';' to allow contents to end in '\' without failing on escape code.
This has the drawback of requiring the parser to trim a single '"' off of the value, but seems to work.

Fixes #35