### PR TITLE
Export dataPos.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -234,7 +234,7 @@ func (r *Rule) option(key item, l *lexer) error {
 		}
 		r.Description = nextItem.value
 	case isStickyBuffer(key.value):
-		var d dataPos
+		var d DataPos
 		var err error
 		if d, err = StickyBuffer(key.value); err != nil {
 			return err

--- a/rule.go
+++ b/rule.go
@@ -83,10 +83,10 @@ type Network struct {
 	Ports []string // Currently just []string because these can be variables $HTTP_PORTS, not just ints.
 }
 
-type dataPos int
+type DataPos int
 
 const (
-	pktData dataPos = iota
+	pktData DataPos = iota
 	fileData
 	base64Data
 	// HTTP Sticky buffers
@@ -124,7 +124,7 @@ const (
 	smbShare
 )
 
-var stickyBuffers = map[dataPos]string{
+var stickyBuffers = map[DataPos]string{
 	pktData:    "pkt_data",
 	fileData:   "file_data",
 	base64Data: "base64_data",
@@ -163,12 +163,12 @@ var stickyBuffers = map[dataPos]string{
 	smbShare:     "smb_share",
 }
 
-func (d dataPos) String() string {
+func (d DataPos) String() string {
 	return stickyBuffers[d]
 }
 
 // StickyBuffer returns the data position value for the string representation of a sticky buffer name (e.g. "file_data")
-func StickyBuffer(s string) (dataPos, error) {
+func StickyBuffer(s string) (DataPos, error) {
 	for k, v := range stickyBuffers {
 		if v == s {
 			return k, nil
@@ -186,7 +186,7 @@ func isStickyBuffer(s string) bool {
 type Content struct {
 	// DataPosition defaults to pkt_data state, can be modified to apply to file_data, base64_data locations.
 	// This value will apply to all following contents, to reset to default you must reset DataPosition during processing.
-	DataPosition dataPos
+	DataPosition DataPos
 	// FastPattern settings for the content.
 	FastPattern FastPattern
 	// Pattern is the pattern match of a content (e.g. HTTP in content:"HTTP").

--- a/rule_test.go
+++ b/rule_test.go
@@ -654,7 +654,7 @@ func TestRE(t *testing.T) {
 
 func TestDataPosString(t *testing.T) {
 	for _, tt := range []struct {
-		val  dataPos
+		val  DataPos
 		want string
 	}{
 		{
@@ -705,7 +705,7 @@ func TestIsStickyBuffer(t *testing.T) {
 func TestStickyBuffer(t *testing.T) {
 	for _, tt := range []struct {
 		s       string
-		want    dataPos
+		want    DataPos
 		wantErr bool
 	}{
 		{


### PR DESCRIPTION
Current exported function StickyBuffer() returns an unexported type
which is not fun to work with.

@jakewarren let me know if this breaks you at all.