### PR TITLE
ADD trimspace to trim space in byte_extract

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -358,7 +358,7 @@ func (r *Rule) option(key item, l *lexer) error {
 		}
 		v.NumBytes = n
 
-		offset, err := strconv.Atoi(parts[1])
+		offset, err := strconv.Atoi(strings.TrimSpace(parts[1]))
 		if err != nil {
 			return fmt.Errorf("byte_extract offset is not an int: %s; %s", parts[1], err)
 		}


### PR DESCRIPTION

in somecase like rule below, it will parse fail, so add trimsapce to trim space:
alert ip $EXTERNAL_NET any -> $HOME_NET any (msg:"EXPLOIT RCE "; content: "M"; offset: 0; depth: 2; content: "Z"; distance: -2; within: 3; content: "PE"; offset: 64; depth: 2; byte_test: 4, >, 0, 70, little; byte_extract: 4, 144, cve20162208, little; byte_test: 4, >, cve20162208, 328, little; flow: no_stream; reference: cve,2016-2208; classtype:attempted-admin; sid:10000057; rev:1; metadata:None;)
