### PR TITLE
Standalone tag style keywords. Super basic support.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -175,7 +175,13 @@ func (r *Rule) option(key item, l *lexer) error {
 		panic("item is not an option key")
 	}
 	switch {
-	case inSlice(key.value, []string{"classtype", "flow", "threshold", "tag", "priority", "dsize", "urilen", "tls.store", "flags"}):
+	// TODO(duane): Many of these simple tags could be factored into nicer structures.
+	case inSlice(key.value, []string{"classtype", "flow", "tag", "priority", "dsize", "urilen", "app-layer-protocol",
+		"flags", "ttl", "ipopts", "ip_proto", "id", "geoip", "fragbits", "fragoffset", "tos",
+		"seq", "window", "ack",
+		"threshold", "detection_filter",
+		"dce_iface", "dce_opnum", "dce_stub_data",
+		"asn1"}):
 		nextItem := l.nextItem()
 		if nextItem.typ != itemOptionValue {
 			return fmt.Errorf("no valid value for %s tag", key.value)
@@ -184,6 +190,8 @@ func (r *Rule) option(key item, l *lexer) error {
 			r.Tags = make(map[string]string)
 		}
 		r.Tags[key.value] = nextItem.value
+	case inSlice(key.value, []string{"sameip", "tls.store", "ftpbounce"}):
+		r.Statements = append(r.Statements, key.value)
 	case inSlice(key.value, tlsTags):
 		t := &TLSTag{
 			Key: key.value,

--- a/rule.go
+++ b/rule.go
@@ -56,6 +56,8 @@ type Rule struct {
 	ByteMatchers []*ByteMatch
 	// Tags is a map of tag names to tag values (e.g. classtype:trojan).
 	Tags map[string]string
+	// Statements is a slice of string. These items are similar to Tags, but have no value. (e.g. 'sameip;')
+	Statements []string
 	// TLSTags is a slice of TLS related matches.
 	TLSTags []*TLSTag
 	// StreamMatch holds stream_size parameters.
@@ -708,6 +710,10 @@ func (r Rule) String() string {
 
 	for k, v := range r.Tags {
 		s.WriteString(fmt.Sprintf("%s:%s; ", k, v))
+	}
+
+	for _, v := range r.Statements {
+		s.WriteString(fmt.Sprintf("%s; ", v))
 	}
 
 	for _, fb := range r.Flowbits {


### PR DESCRIPTION
Add support for the last of the missing (non-deprecated) keywords from ET OPEN.
closes #53 