### PR TITLE
Refactor ICMP specific length matchers to include other length checks,

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -285,7 +285,7 @@ func TestParseRule(t *testing.T) {
 						Pattern: []byte("AA"), Negate: true},
 				},
 				TLSTags: []*TLSTag{
-					&TLSTag{
+					{
 						Negate: true,
 						Key:    "tls.subject",
 						Value:  "CN=*.googleusercontent.com",
@@ -314,7 +314,13 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Tags:        map[string]string{"dsize": ">19"},
+				LenMatchers: []*LenMatch{
+					{
+						Kind:     dSize,
+						Operator: ">",
+						Num:      19,
+					},
+				},
 			},
 		},
 		{
@@ -358,8 +364,8 @@ func TestParseRule(t *testing.T) {
 				SID:         1337,
 				Revision:    1,
 				Description: "foo",
-				ICMPMatchers: []*ICMPMatch{
-					&ICMPMatch{
+				LenMatchers: []*LenMatch{
+					{
 						Kind:     iType,
 						Operator: ">",
 						Num:      10,
@@ -389,8 +395,8 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				References: []*Reference{
-					&Reference{Type: "cve", Value: "2014"},
-					&Reference{Type: "url", Value: "www.suricata-ids.org"},
+					{Type: "cve", Value: "2014"},
+					{Type: "url", Value: "www.suricata-ids.org"},
 				},
 				Matchers: []orderedMatcher{
 					&Content{
@@ -420,8 +426,8 @@ func TestParseRule(t *testing.T) {
 						Pattern: []byte("AA"),
 						Negate:  true,
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"offset", "3"},
+							{"http_header", ""},
+							{"offset", "3"},
 						},
 					},
 				},
@@ -430,8 +436,8 @@ func TestParseRule(t *testing.T) {
 						Pattern: []byte("AA"),
 						Negate:  true,
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"offset", "3"},
+							{"http_header", ""},
+							{"offset", "3"},
 						},
 					},
 				},
@@ -457,14 +463,14 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
+							{"http_header", ""},
 						},
 						FastPattern: FastPattern{Enabled: true},
 					},
 					&Content{
 						Pattern: []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -472,14 +478,14 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
+							{"http_header", ""},
 						},
 						FastPattern: FastPattern{Enabled: true},
 					},
 					&Content{
 						Pattern: []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -505,15 +511,15 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 						FastPattern: FastPattern{Enabled: true, Offset: 0, Length: 42},
 					},
 					&Content{
 						Pattern: []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -521,15 +527,15 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 						FastPattern: FastPattern{Enabled: true, Offset: 0, Length: 42},
 					},
 					&Content{
 						Pattern: []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -556,15 +562,15 @@ func TestParseRule(t *testing.T) {
 						DataPosition: fileData,
 						Pattern:      []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 					},
 					&Content{
 						DataPosition: fileData,
 						Pattern:      []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -573,15 +579,15 @@ func TestParseRule(t *testing.T) {
 						DataPosition: fileData,
 						Pattern:      []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 					},
 					&Content{
 						DataPosition: fileData,
 						Pattern:      []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -643,22 +649,22 @@ func TestParseRule(t *testing.T) {
 						DataPosition: fileData,
 						Pattern:      []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 					},
 					&Content{
 						DataPosition: fileData,
 						Pattern:      []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 					&Content{
 						DataPosition: pktData,
 						Pattern:      []byte("C"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -667,22 +673,22 @@ func TestParseRule(t *testing.T) {
 						DataPosition: fileData,
 						Pattern:      []byte("A"),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
-							&ContentOption{"nocase", ""},
+							{"http_header", ""},
+							{"nocase", ""},
 						},
 					},
 					&Content{
 						DataPosition: fileData,
 						Pattern:      []byte("B"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 					&Content{
 						DataPosition: pktData,
 						Pattern:      []byte("C"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -717,7 +723,7 @@ func TestParseRule(t *testing.T) {
 						DataPosition: pktData,
 						Pattern:      []byte("C"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -734,7 +740,7 @@ func TestParseRule(t *testing.T) {
 						DataPosition: pktData,
 						Pattern:      []byte("C"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
@@ -762,7 +768,7 @@ func TestParseRule(t *testing.T) {
 						DataPosition: dnsQuery,
 						Pattern:      []byte("google.com"),
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
+							{"nocase", ""},
 						},
 					},
 				},
@@ -771,7 +777,7 @@ func TestParseRule(t *testing.T) {
 						DataPosition: dnsQuery,
 						Pattern:      []byte("google.com"),
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
+							{"nocase", ""},
 						},
 					},
 				},
@@ -793,24 +799,24 @@ func TestParseRule(t *testing.T) {
 				SID:         17904,
 				Revision:    6,
 				Description: "VRT BLACKLIST URI request for known malicious URI - /tongji.js",
-				References:  []*Reference{&Reference{Type: "url", Value: "labs.snort.org/docs/17904.html"}},
+				References:  []*Reference{{Type: "url", Value: "labs.snort.org/docs/17904.html"}},
 				Contents: Contents{
 					&Content{
 						Pattern: []byte("/tongji.js"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 						FastPattern: FastPattern{Enabled: true, Only: true},
 					},
 					&Content{
 						Pattern: append([]byte("Host"), 0x3a, 0x20),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
+							{"http_header", ""},
 						},
 					},
 				},
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte(`Host\x3a[^\r\n]*?\.tongji`),
 						Options: []byte("Hi"),
 					},
@@ -830,14 +836,14 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("/tongji.js"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 						FastPattern: FastPattern{Enabled: true, Only: true},
 					},
 					&Content{
 						Pattern: append([]byte("Host"), 0x3a, 0x20),
 						Options: []*ContentOption{
-							&ContentOption{"http_header", ""},
+							{"http_header", ""},
 						},
 					},
 					&PCRE{
@@ -864,7 +870,7 @@ func TestParseRule(t *testing.T) {
 				Revision:    1,
 				Description: "Foo msg",
 				References: []*Reference{
-					&Reference{
+					{
 						Type:  "url",
 						Value: "www.google.com"},
 				},
@@ -872,12 +878,12 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("blah"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte("foo.*bar"),
 						Options: []byte("Ui"),
 					},
@@ -890,7 +896,7 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("blah"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 					&PCRE{
@@ -916,7 +922,7 @@ func TestParseRule(t *testing.T) {
 				Revision:    3,
 				Description: "ET SHELLCODE Berlin Shellcode",
 				References: []*Reference{
-					&Reference{
+					{
 						Type:  "url",
 						Value: "doc.emergingthreats.net/2009256"},
 				},
@@ -927,7 +933,7 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},
 						Options: []*ContentOption{
-							&ContentOption{"distance", "0"},
+							{"distance", "0"},
 						},
 					},
 				},
@@ -943,7 +949,7 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},
 						Options: []*ContentOption{
-							&ContentOption{"distance", "0"},
+							{"distance", "0"},
 						},
 					},
 				},
@@ -975,8 +981,8 @@ func TestParseRule(t *testing.T) {
 						Pattern:      []byte("name=chalbhai"),
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 						FastPattern: FastPattern{Enabled: true},
 					},
@@ -984,16 +990,16 @@ func TestParseRule(t *testing.T) {
 						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 					},
 					&Content{
 						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 					},
 				},
@@ -1012,8 +1018,8 @@ func TestParseRule(t *testing.T) {
 						Pattern:      []byte("name=chalbhai"),
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 						FastPattern: FastPattern{Enabled: true},
 					},
@@ -1021,16 +1027,16 @@ func TestParseRule(t *testing.T) {
 						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 					},
 					&Content{
 						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
 						DataPosition: fileData,
 						Options: []*ContentOption{
-							&ContentOption{"nocase", ""},
-							&ContentOption{"distance", "0"},
+							{"nocase", ""},
+							{"distance", "0"},
 						},
 					},
 				},
@@ -1054,7 +1060,7 @@ func TestParseRule(t *testing.T) {
 				Revision:    1,
 				Description: "Negated PCRE",
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte("foo.*bar"),
 						Negate:  true,
 						Options: []byte("Ui"),
@@ -1087,7 +1093,7 @@ func TestParseRule(t *testing.T) {
 				Revision:    1,
 				Description: "PCRE with quote",
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte(`=[."]\w{8}\.jar`),
 						Options: []byte("Hi"),
 					},
@@ -1124,13 +1130,13 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte{0x55, 0x04, 0x0A, 0x0C, 0x0C},
 						Options: []*ContentOption{
-							&ContentOption{"distance", "3"},
-							&ContentOption{"within", "Certs.len"},
+							{"distance", "3"},
+							{"within", "Certs.len"},
 						},
 					},
 				},
 				ByteMatchers: []*ByteMatch{
-					&ByteMatch{
+					{
 						Kind:     bExtract,
 						NumBytes: 3,
 						Variable: "Certs.len",
@@ -1150,8 +1156,8 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte{0x55, 0x04, 0x0A, 0x0C, 0x0C},
 						Options: []*ContentOption{
-							&ContentOption{"distance", "3"},
-							&ContentOption{"within", "Certs.len"},
+							{"distance", "3"},
+							{"within", "Certs.len"},
 						},
 					},
 				},
@@ -1180,7 +1186,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				ByteMatchers: []*ByteMatch{
-					&ByteMatch{
+					{
 						Kind:     bTest,
 						NumBytes: 5,
 						Operator: "<",
@@ -1227,7 +1233,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				ByteMatchers: []*ByteMatch{
-					&ByteMatch{
+					{
 						Kind:     bJump,
 						NumBytes: 4,
 						Offset:   0,
@@ -1268,18 +1274,18 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("aabb"),
 						Options: []*ContentOption{
-							&ContentOption{"depth", "4"},
+							{"depth", "4"},
 						},
 					},
 				},
 				ByteMatchers: []*ByteMatch{
-					&ByteMatch{
+					{
 						Kind:     bJump,
 						NumBytes: 2,
 						Offset:   3,
 						Options:  []string{"post_offset -1"},
 					},
-					&ByteMatch{
+					{
 						Kind:     isDataAt,
 						Negate:   true,
 						NumBytes: 2,
@@ -1290,7 +1296,7 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("aabb"),
 						Options: []*ContentOption{
-							&ContentOption{"depth", "4"},
+							{"depth", "4"},
 						},
 					},
 					&ByteMatch{
@@ -1361,7 +1367,7 @@ func TestParseRule(t *testing.T) {
 					},
 				},
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte(`this.*`),
 						Options: []byte("R"),
 					},
@@ -1405,16 +1411,16 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("testflowbits"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},
 				Flowbits: []*Flowbit{
-					&Flowbit{
+					{
 						Action: "set",
 						Value:  "testbits",
 					},
-					&Flowbit{
+					{
 						Action: "noalert",
 						Value:  "",
 					},
@@ -1423,7 +1429,7 @@ func TestParseRule(t *testing.T) {
 					&Content{
 						Pattern: []byte("testflowbits"),
 						Options: []*ContentOption{
-							&ContentOption{"http_uri", ""},
+							{"http_uri", ""},
 						},
 					},
 				},

--- a/rule.go
+++ b/rule.go
@@ -62,8 +62,8 @@ type Rule struct {
 	TLSTags []*TLSTag
 	// StreamMatch holds stream_size parameters.
 	StreamMatch *StreamCmp
-	// ICMPMatchers is a slice of ICMP matches.
-	ICMPMatchers []*ICMPMatch
+	// LenMatchers is a slice of ICMP matches.
+	LenMatchers []*LenMatch
 	// Metas is a slice of Metadata.
 	Metas Metadatas
 	// Flowbits is a slice of Flowbit.
@@ -263,14 +263,14 @@ func byteMatcher(s string) (byteMatchType, error) {
 	return bUnknown, fmt.Errorf("%s is not a byteMatchType* keyword", s)
 }
 
-// icmpMatcher returns an icmpMatchType or an error for a given string.
-func icmpMatcher(s string) (icmpMatchType, error) {
-	for k, v := range icmpMatchTypeVals {
+// lenMatcher returns an lenMatchType or an error for a given string.
+func lenMatcher(s string) (lenMatchType, error) {
+	for k, v := range lenMatchTypeVals {
 		if v == s {
 			return k, nil
 		}
 	}
-	return iUnknown, fmt.Errorf("%s is not an icmp keyword", s)
+	return lUnknown, fmt.Errorf("%s is not an icmp keyword", s)
 }
 
 // Returns the number of mandatory parameters for a byteMatchType keyword, -1 if unknown.
@@ -311,44 +311,56 @@ type ByteMatch struct {
 	Options []string
 }
 
-// icmpMatchType describes the type of ICMP matches and comparisons that are supported.
-type icmpMatchType int
+// lenMatchType describes the type of ICMP matches and comparisons that are supported.
+type lenMatchType int
 
 const (
-	iUnknown icmpMatchType = iota
+	lUnknown lenMatchType = iota
 	iType
 	iCode
 	iID
 	iSeq
+	uriLen
+	dSize
+	ipTTL
+	ipID
+	tcpSeq
+	tcpACK
 )
 
-// icmpMatchTypeVals map icmp types to string representations.
-var icmpMatchTypeVals = map[icmpMatchType]string{
-	iType: "itype",
-	iCode: "icode",
-	iID:   "icmp_id",
-	iSeq:  "icmp_seq",
+// lenMatchTypeVals map len types to string representations.
+var lenMatchTypeVals = map[lenMatchType]string{
+	iType:  "itype",
+	iCode:  "icode",
+	iID:    "icmp_id",
+	iSeq:   "icmp_seq",
+	uriLen: "urilen",
+	dSize:  "dsize",
+	ipTTL:  "ttl",
+	ipID:   "id",
+	tcpSeq: "seq",
+	tcpACK: "ack",
 }
 
-// allICMPMatchTypeNames returns a slice of string containg all ICMP match keywords.
-func allICMPMatchTypeNames() []string {
-	i := make([]string, len(icmpMatchTypeVals))
+// allLenMatchTypeNames returns a slice of string containg all ICMP match keywords.
+func allLenMatchTypeNames() []string {
+	i := make([]string, len(lenMatchTypeVals))
 	var j int
-	for _, n := range icmpMatchTypeVals {
+	for _, n := range lenMatchTypeVals {
 		i[j] = n
 		j++
 	}
 	return i
 }
 
-// String returns the string keyword for an icmpMatchType.
-func (i icmpMatchType) String() string {
-	return icmpMatchTypeVals[i]
+// String returns the string keyword for an lenMatchType.
+func (i lenMatchType) String() string {
+	return lenMatchTypeVals[i]
 }
 
-// ICMPMatch holds the values to represent an ICMP Match.
-type ICMPMatch struct {
-	Kind     icmpMatchType
+// LenMatch holds the values to represent an ICMP Match.
+type LenMatch struct {
+	Kind     lenMatchType
 	Min      int
 	Max      int
 	Num      int
@@ -575,7 +587,7 @@ func (b ByteMatch) String() string {
 }
 
 // String returns a string for an ICMP match.
-func (i ICMPMatch) String() string {
+func (i LenMatch) String() string {
 	if i.Operator == "<>" {
 		return fmt.Sprintf("%s:%d%s%d;", i.Kind, i.Min, i.Operator, i.Max)
 	}
@@ -693,8 +705,8 @@ func (r Rule) String() string {
 		s.WriteString(fmt.Sprintf("%s ", r.StreamMatch))
 	}
 
-	if len(r.ICMPMatchers) > 0 {
-		for _, i := range r.ICMPMatchers {
+	if len(r.LenMatchers) > 0 {
+		for _, i := range r.LenMatchers {
 			s.WriteString(fmt.Sprintf("%s ", i))
 		}
 	}

--- a/rule_test.go
+++ b/rule_test.go
@@ -448,12 +448,12 @@ func TestTLSTagString(t *testing.T) {
 func TestICMPMatchString(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
-		input *ICMPMatch
+		input *LenMatch
 		want  string
 	}{
 		{
 			name: "no operator",
-			input: &ICMPMatch{
+			input: &LenMatch{
 				Kind: iCode,
 				Num:  3,
 			},
@@ -461,7 +461,7 @@ func TestICMPMatchString(t *testing.T) {
 		},
 		{
 			name: "single operator",
-			input: &ICMPMatch{
+			input: &LenMatch{
 				Kind:     iCode,
 				Operator: ">",
 				Num:      3,
@@ -470,7 +470,7 @@ func TestICMPMatchString(t *testing.T) {
 		},
 		{
 			name: "min and max",
-			input: &ICMPMatch{
+			input: &LenMatch{
 				Kind:     iType,
 				Operator: "<>",
 				Min:      1,
@@ -519,7 +519,7 @@ func TestContentString(t *testing.T) {
 			input: Content{
 				Pattern: []byte("AA"),
 				Options: []*ContentOption{
-					&ContentOption{
+					{
 						Name: "http_uri",
 					},
 				},
@@ -531,10 +531,10 @@ func TestContentString(t *testing.T) {
 			input: Content{
 				Pattern: []byte("AA"),
 				Options: []*ContentOption{
-					&ContentOption{
+					{
 						Name: "http_uri",
 					},
-					&ContentOption{
+					{
 						Name:  "depth",
 						Value: "0",
 					},
@@ -547,10 +547,10 @@ func TestContentString(t *testing.T) {
 			input: Content{
 				Pattern: []byte("AA"),
 				Options: []*ContentOption{
-					&ContentOption{
+					{
 						Name: "http_uri",
 					},
-					&ContentOption{
+					{
 						Name:  "depth",
 						Value: "0",
 					},
@@ -637,11 +637,11 @@ func TestContentsString(t *testing.T) {
 						Enabled: true,
 					},
 					Options: []*ContentOption{
-						&ContentOption{
+						{
 							Name:  "offset",
 							Value: "10",
 						},
-						&ContentOption{
+						{
 							Name:  "depth",
 							Value: "50",
 						},
@@ -791,7 +791,7 @@ func TestRuleString(t *testing.T) {
 					},
 				},
 				PCREs: []*PCRE{
-					&PCRE{
+					{
 						Pattern: []byte("foo.*bar"),
 						Options: []byte("Ui"),
 					},
@@ -857,11 +857,11 @@ func TestRuleString(t *testing.T) {
 				Revision:    3,
 				Description: "Flowbits test",
 				Flowbits: []*Flowbit{
-					&Flowbit{
+					{
 						Action: "set",
 						Value:  "testbits",
 					},
-					&Flowbit{
+					{
 						Action: "noalert",
 						Value:  "",
 					},


### PR DESCRIPTION
Refactor ICMP specific length matchers to include other length checks, like urilen, seq, etc.
Some automatic linting cleanup too.