### PR TITLE
Dup refactor

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -24,7 +24,7 @@ func (r *Rule) ShouldBeHTTP() bool {
 		return false
 	}
 	// If we look at http buffers or sticky buffers, we should use the HTTP protocol.
-	for _, c := range r.Contents {
+	for _, c := range r.Contents() {
 		if strings.HasPrefix(c.DataPosition.String(), "http_") {
 			return true
 		}

--- a/linters_test.go
+++ b/linters_test.go
@@ -44,7 +44,7 @@ func TestShouldBeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"$HTTP_PORTS"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
 						Options: []*ContentOption{
@@ -67,7 +67,7 @@ func TestShouldBeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"$HTTP_PORTS"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: httpProtocol,
 						Pattern:      []byte("AA"),

--- a/optimize_test.go
+++ b/optimize_test.go
@@ -46,7 +46,7 @@ func TestOptimizeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"$HTTP_PORTS"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
 						Options: []*ContentOption{
@@ -65,7 +65,7 @@ func TestOptimizeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"any"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
 						Options: []*ContentOption{
@@ -94,7 +94,7 @@ func TestOptimizeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"$HTTP_PORTS"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: httpProtocol,
 						Pattern:      []byte("AA"),
@@ -111,7 +111,7 @@ func TestOptimizeHTTP(t *testing.T) {
 					Nets:  []string{"$EXTERNAL_NET"},
 					Ports: []string{"any"},
 				},
-				Contents: Contents{
+				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: httpProtocol,
 						Pattern:      []byte("AA"),

--- a/parser.go
+++ b/parser.go
@@ -296,7 +296,6 @@ func (r *Rule) option(key item, l *lexer) error {
 				Negate:       negate,
 				Options:      options,
 			}
-			r.Contents = append(r.Contents, con)
 			r.Matchers = append(r.Matchers, con)
 		} else {
 			return fmt.Errorf("invalid type %q for option content", nextItem.typ)
@@ -304,13 +303,13 @@ func (r *Rule) option(key item, l *lexer) error {
 	case inSlice(key.value, []string{"http_cookie", "http_raw_cookie", "http_method", "http_header", "http_raw_header",
 		"http_uri", "http_raw_uri", "http_user_agent", "http_stat_code", "http_stat_msg",
 		"http_client_body", "http_server_body", "http_host", "nocase", "rawbytes"}):
-		if len(r.Contents) == 0 {
+		if len(r.Contents()) == 0 {
 			return fmt.Errorf("invalid content option %q with no content match", key.value)
 		}
-		lastContent := r.Contents[len(r.Contents)-1]
+		lastContent := r.Contents()[len(r.Contents())-1]
 		lastContent.Options = append(lastContent.Options, &ContentOption{Name: key.value})
 	case inSlice(key.value, []string{"depth", "distance", "offset", "within"}):
-		if len(r.Contents) == 0 {
+		if len(r.Contents()) == 0 {
 			return fmt.Errorf("invalid content option %q with no content match", key.value)
 		}
 		nextItem := l.nextItem()
@@ -318,11 +317,11 @@ func (r *Rule) option(key item, l *lexer) error {
 			return fmt.Errorf("no value for content option %s", key.value)
 		}
 
-		lastContent := r.Contents[len(r.Contents)-1]
+		lastContent := r.Contents()[len(r.Contents())-1]
 		lastContent.Options = append(lastContent.Options, &ContentOption{Name: key.value, Value: nextItem.value})
 
 	case key.value == "fast_pattern":
-		if len(r.Contents) == 0 {
+		if len(r.Contents()) == 0 {
 			return fmt.Errorf("invalid content option %q with no content match", key.value)
 		}
 		var (
@@ -350,7 +349,7 @@ func (r *Rule) option(key item, l *lexer) error {
 				length = i
 			}
 		}
-		lastContent := r.Contents[len(r.Contents)-1]
+		lastContent := r.Contents()[len(r.Contents())-1]
 		lastContent.FastPattern = FastPattern{true, only, offset, length}
 	case key.value == "pcre":
 		nextItem := l.nextItem()

--- a/parser.go
+++ b/parser.go
@@ -364,7 +364,6 @@ func (r *Rule) option(key item, l *lexer) error {
 				return err
 			}
 			p.Negate = negate
-			r.PCREs = append(r.PCREs, p)
 			r.Matchers = append(r.Matchers, p)
 		} else {
 			return fmt.Errorf("invalid type %q for option content", nextItem.typ)

--- a/parser.go
+++ b/parser.go
@@ -435,7 +435,6 @@ func (r *Rule) option(key item, l *lexer) error {
 			b.Options = append(b.Options, parts[i])
 		}
 
-		r.ByteMatchers = append(r.ByteMatchers, b)
 		r.Matchers = append(r.Matchers, b)
 	case inSlice(key.value, allLenMatchTypeNames()):
 		// TODO: Factor out into unit testable function.

--- a/parser_test.go
+++ b/parser_test.go
@@ -666,12 +666,6 @@ func TestParseRule(t *testing.T) {
 				Revision:    6,
 				Description: "VRT BLACKLIST URI request for known malicious URI - /tongji.js",
 				References:  []*Reference{{Type: "url", Value: "labs.snort.org/docs/17904.html"}},
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte(`Host\x3a[^\r\n]*?\.tongji`),
-						Options: []byte("Hi"),
-					},
-				},
 				Tags: map[string]string{
 					"flow":      "to_server,established",
 					"classtype": "trojan-activity",
@@ -724,12 +718,6 @@ func TestParseRule(t *testing.T) {
 					{
 						Type:  "url",
 						Value: "www.google.com"},
-				},
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte("foo.*bar"),
-						Options: []byte("Ui"),
-					},
 				},
 				Tags: map[string]string{
 					"flow":      "to_server,established",
@@ -860,13 +848,6 @@ func TestParseRule(t *testing.T) {
 				SID:         12345,
 				Revision:    1,
 				Description: "Negated PCRE",
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte("foo.*bar"),
-						Negate:  true,
-						Options: []byte("Ui"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&PCRE{
 						Pattern: []byte("foo.*bar"),
@@ -893,12 +874,6 @@ func TestParseRule(t *testing.T) {
 				SID:         12345,
 				Revision:    1,
 				Description: "PCRE with quote",
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte(`=[."]\w{8}\.jar`),
-						Options: []byte("Hi"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&PCRE{
 						Pattern: []byte(`=[."]\w{8}\.jar`),
@@ -1084,12 +1059,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1,
 				Revision:    1,
 				Description: "check order",
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte(`this.*`),
-						Options: []byte("R"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("1"),

--- a/parser_test.go
+++ b/parser_test.go
@@ -76,11 +76,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -106,11 +101,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -136,11 +126,6 @@ func TestParseRule(t *testing.T) {
 				SID:           1337,
 				Revision:      2,
 				Description:   "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -164,10 +149,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"), Negate: true},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"), Negate: true},
@@ -190,14 +171,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-					&Content{
-						Pattern: []byte("BB"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -224,11 +197,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{'A', 0x42, 0x43, 'D', 0x45},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{'A', 0x42, 0x43, 'D', 0x45},
@@ -252,11 +220,7 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"), Negate: true},
-				},
-				Tags: map[string]string{"classtype": "foo"},
+				Tags:        map[string]string{"classtype": "foo"},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"), Negate: true},
@@ -280,10 +244,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1337,
 				Revision:    1,
 				Description: "tls_subject",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"), Negate: true},
-				},
 				TLSTags: []*TLSTag{
 					{
 						Negate: true,
@@ -416,11 +376,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("A"),
-					},
-				},
 				References: []*Reference{
 					{Type: "cve", Value: "2014"},
 					{Type: "url", Value: "www.suricata-ids.org"},
@@ -448,16 +403,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-						Negate:  true,
-						Options: []*ContentOption{
-							{"http_header", ""},
-							{"offset", "3"},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -486,21 +431,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1,
 				Description: "a",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("A"),
-						Options: []*ContentOption{
-							{"http_header", ""},
-						},
-						FastPattern: FastPattern{Enabled: true},
-					},
-					&Content{
-						Pattern: []byte("B"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("A"),
@@ -534,22 +464,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1,
 				Description: "a",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("A"),
-						Options: []*ContentOption{
-							{"http_header", ""},
-							{"nocase", ""},
-						},
-						FastPattern: FastPattern{Enabled: true, Offset: 0, Length: 42},
-					},
-					&Content{
-						Pattern: []byte("B"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("A"),
@@ -584,23 +498,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1,
 				Description: "a",
-				Contents: Contents{
-					&Content{
-						DataPosition: fileData,
-						Pattern:      []byte("A"),
-						Options: []*ContentOption{
-							{"http_header", ""},
-							{"nocase", ""},
-						},
-					},
-					&Content{
-						DataPosition: fileData,
-						Pattern:      []byte("B"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: fileData,
@@ -637,14 +534,6 @@ func TestParseRule(t *testing.T) {
 				SID:         12345,
 				Revision:    1,
 				Description: "broken rule",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("A"),
-					},
-					&Content{
-						Pattern: []byte("B"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("A"),
@@ -671,30 +560,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1,
 				Description: "a",
-				Contents: Contents{
-					&Content{
-						DataPosition: fileData,
-						Pattern:      []byte("A"),
-						Options: []*ContentOption{
-							{"http_header", ""},
-							{"nocase", ""},
-						},
-					},
-					&Content{
-						DataPosition: fileData,
-						Pattern:      []byte("B"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-					&Content{
-						DataPosition: pktData,
-						Pattern:      []byte("C"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: fileData,
@@ -737,23 +602,6 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1,
 				Description: "a",
-				Contents: Contents{
-					&Content{
-						DataPosition: httpRequestLine,
-						Pattern:      []byte("A"),
-					},
-					&Content{
-						DataPosition: httpRequestLine,
-						Pattern:      []byte("B"),
-					},
-					&Content{
-						DataPosition: pktData,
-						Pattern:      []byte("C"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: httpRequestLine,
@@ -790,15 +638,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1234,
 				Revision:    1,
 				Description: "DNS Query for google.com",
-				Contents: Contents{
-					&Content{
-						DataPosition: dnsQuery,
-						Pattern:      []byte("google.com"),
-						Options: []*ContentOption{
-							{"nocase", ""},
-						},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						DataPosition: dnsQuery,
@@ -827,21 +666,6 @@ func TestParseRule(t *testing.T) {
 				Revision:    6,
 				Description: "VRT BLACKLIST URI request for known malicious URI - /tongji.js",
 				References:  []*Reference{{Type: "url", Value: "labs.snort.org/docs/17904.html"}},
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("/tongji.js"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-						FastPattern: FastPattern{Enabled: true, Only: true},
-					},
-					&Content{
-						Pattern: append([]byte("Host"), 0x3a, 0x20),
-						Options: []*ContentOption{
-							{"http_header", ""},
-						},
-					},
-				},
 				PCREs: []*PCRE{
 					{
 						Pattern: []byte(`Host\x3a[^\r\n]*?\.tongji`),
@@ -901,14 +725,6 @@ func TestParseRule(t *testing.T) {
 						Type:  "url",
 						Value: "www.google.com"},
 				},
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("blah"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
-				},
 				PCREs: []*PCRE{
 					{
 						Pattern: []byte("foo.*bar"),
@@ -953,17 +769,6 @@ func TestParseRule(t *testing.T) {
 						Type:  "url",
 						Value: "doc.emergingthreats.net/2009256"},
 				},
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{0x31, 0xc9, 0xb1, 0xfc, 0x80, 0x73, 0x0c},
-					},
-					&Content{
-						Pattern: []byte{0x43, 0xe2, 0x8b, 0x9f},
-						Options: []*ContentOption{
-							{"distance", "0"},
-						},
-					},
-				},
 				Tags: map[string]string{"flow": "established", "classtype": "shellcode-detect"},
 				Metas: Metadatas{
 					&Metadata{Key: "created_at", Value: "2010_07_30"},
@@ -999,38 +804,7 @@ func TestParseRule(t *testing.T) {
 				SID:         2025692,
 				Revision:    2,
 				Description: "ET CURRENT_EVENTS Chase Account Phish Landing Oct 22",
-				Contents: Contents{
-					&Content{
-						Pattern:      []byte("<title>Sign in</title>"),
-						DataPosition: fileData,
-					},
-					&Content{
-						Pattern:      []byte("name=chalbhai"),
-						DataPosition: fileData,
-						Options: []*ContentOption{
-							{"nocase", ""},
-							{"distance", "0"},
-						},
-						FastPattern: FastPattern{Enabled: true},
-					},
-					&Content{
-						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
-						DataPosition: fileData,
-						Options: []*ContentOption{
-							{"nocase", ""},
-							{"distance", "0"},
-						},
-					},
-					&Content{
-						Pattern:      []byte{0x72, 0x65, 0x71, 0x75, 0x69, 0x72, 0x65, 0x64, 0x20, 0x74, 0x69, 0x74, 0x6c, 0x65, 0x3d, 0x22, 0x50, 0x6c, 0x65, 0x61, 0x73, 0x65, 0x20, 0x45, 0x6e, 0x74, 0x65, 0x72, 0x20, 0x52, 0x69, 0x67, 0x68, 0x74, 0x20, 0x56, 0x61, 0x6c, 0x75, 0x65, 0x22},
-						DataPosition: fileData,
-						Options: []*ContentOption{
-							{"nocase", ""},
-							{"distance", "0"},
-						},
-					},
-				},
-				Tags: map[string]string{"flow": "established,from_server", "classtype": "trojan-activity"},
+				Tags:        map[string]string{"flow": "established,from_server", "classtype": "trojan-activity"},
 				Metas: Metadatas{
 					&Metadata{Key: "former_category", Value: "CURRENT_EVENTS"},
 					&Metadata{Key: "created_at", Value: "2015_10_22"},
@@ -1150,18 +924,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_extract",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{0xff, 0xfe},
-					},
-					&Content{
-						Pattern: []byte{0x55, 0x04, 0x0A, 0x0C, 0x0C},
-						Options: []*ContentOption{
-							{"distance", "3"},
-							{"within", "Certs.len"},
-						},
-					},
-				},
 				ByteMatchers: []*ByteMatch{
 					{
 						Kind:     bExtract,
@@ -1207,11 +969,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_test",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{0xff, 0xfe},
-					},
-				},
 				ByteMatchers: []*ByteMatch{
 					{
 						Kind:     bTest,
@@ -1254,11 +1011,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_jump",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{0xff, 0xfe},
-					},
-				},
 				ByteMatchers: []*ByteMatch{
 					{
 						Kind:     bJump,
@@ -1297,14 +1049,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "isdataat",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("aabb"),
-						Options: []*ContentOption{
-							{"depth", "4"},
-						},
-					},
-				},
 				ByteMatchers: []*ByteMatch{
 					{
 						Kind:     bJump,
@@ -1357,11 +1101,6 @@ func TestParseRule(t *testing.T) {
 				SID:         12345,
 				Revision:    2,
 				Description: "ending backslash rule",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte{0x66, 0x6f, 0x6f, 0x5c},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{0x66, 0x6f, 0x6f, 0x5c},
@@ -1385,14 +1124,6 @@ func TestParseRule(t *testing.T) {
 				SID:         1,
 				Revision:    1,
 				Description: "check order",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("1"),
-					},
-					&Content{
-						Pattern: []byte("2"),
-					},
-				},
 				PCREs: []*PCRE{
 					{
 						Pattern: []byte(`this.*`),
@@ -1433,14 +1164,6 @@ func TestParseRule(t *testing.T) {
 				Tags: map[string]string{
 					"flow":      "to_server,established",
 					"classtype": "test_page",
-				},
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("testflowbits"),
-						Options: []*ContentOption{
-							{"http_uri", ""},
-						},
-					},
 				},
 				Flowbits: []*Flowbit{
 					{

--- a/parser_test.go
+++ b/parser_test.go
@@ -924,14 +924,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_extract",
-				ByteMatchers: []*ByteMatch{
-					{
-						Kind:     bExtract,
-						NumBytes: 3,
-						Variable: "Certs.len",
-						Options:  []string{"relative", "little"},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{0xff, 0xfe},
@@ -969,16 +961,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_test",
-				ByteMatchers: []*ByteMatch{
-					{
-						Kind:     bTest,
-						NumBytes: 5,
-						Operator: "<",
-						Value:    "65537",
-						Offset:   0,
-						Options:  []string{"relative", "string"},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{0xff, 0xfe},
@@ -1011,14 +993,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "byte_jump",
-				ByteMatchers: []*ByteMatch{
-					{
-						Kind:     bJump,
-						NumBytes: 4,
-						Offset:   0,
-						Options:  []string{"relative", "little", "post_offset -1"},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{0xff, 0xfe},
@@ -1049,20 +1023,6 @@ func TestParseRule(t *testing.T) {
 				SID:         42,
 				Revision:    1,
 				Description: "isdataat",
-				ByteMatchers: []*ByteMatch{
-					{
-						Kind:     bJump,
-						NumBytes: 2,
-						Offset:   3,
-						Options:  []string{"post_offset -1"},
-					},
-					{
-						Kind:     isDataAt,
-						Negate:   true,
-						NumBytes: 2,
-						Options:  []string{"relative"},
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("aabb"),

--- a/rule.go
+++ b/rule.go
@@ -47,8 +47,6 @@ type Rule struct {
 	References []*Reference
 	// Contents are all the decoded content matches.
 	PCREs []*PCRE
-	// ByteMatchers is a slice of ByteMatch structs.
-	ByteMatchers []*ByteMatch
 	// Tags is a map of tag names to tag values (e.g. classtype:trojan).
 	Tags map[string]string
 	// Statements is a slice of string. These items are similar to Tags, but have no value. (e.g. 'sameip;')
@@ -458,7 +456,7 @@ func (r *Rule) CVE() string {
 	return ""
 }
 
-// Contents returns a []*Content for a rule.
+// Contents returns all *Content for a rule.
 func (r *Rule) Contents() []*Content {
 	var cs []*Content
 	for _, m := range r.Matchers {
@@ -467,6 +465,17 @@ func (r *Rule) Contents() []*Content {
 		}
 	}
 	return cs
+}
+
+// ByteMatchers returns all *ByteMatch for a rule.
+func (r *Rule) ByteMatchers() []*ByteMatch {
+	var bs []*ByteMatch
+	for _, m := range r.Matchers {
+		if b, ok := m.(*ByteMatch); ok {
+			bs = append(bs, b)
+		}
+	}
+	return bs
 }
 
 func netString(netPart []string) string {

--- a/rule.go
+++ b/rule.go
@@ -46,8 +46,6 @@ type Rule struct {
 	// References contains references associated to the rule (e.g. CVE number).
 	References []*Reference
 	// Contents are all the decoded content matches.
-	Contents Contents
-	// PCREs is a slice of PCRE structs that represent the regular expressions in a rule.
 	PCREs []*PCRE
 	// ByteMatchers is a slice of ByteMatch structs.
 	ByteMatchers []*ByteMatch
@@ -212,9 +210,6 @@ type Content struct {
 	// Options are the option associated to the content (e.g. http_header).
 	Options []*ContentOption
 }
-
-// Contents is used so we can have a target type for a Stringer.
-type Contents []*Content
 
 // byteMatchType describes the kinds of byte matches and comparisons that are supported.
 type byteMatchType int
@@ -441,7 +436,7 @@ func within(options []*ContentOption) string {
 // RE returns all content matches as a single and simple regexp.
 func (r *Rule) RE() string {
 	var re string
-	for _, c := range r.Contents {
+	for _, c := range r.Contents() {
 		// TODO: handle pcre, depth, offset, distance.
 		if d, err := strconv.Atoi(within(c.Options)); err == nil && d > 0 {
 			re += fmt.Sprintf(".{0,%d}", d)
@@ -461,6 +456,17 @@ func (r *Rule) CVE() string {
 		}
 	}
 	return ""
+}
+
+// Contents returns a []*Content for a rule.
+func (r *Rule) Contents() []*Content {
+	var cs []*Content
+	for _, m := range r.Matchers {
+		if c, ok := m.(*Content); ok {
+			cs = append(cs, c)
+		}
+	}
+	return cs
 }
 
 func netString(netPart []string) string {
@@ -540,21 +546,6 @@ func (c Content) String() string {
 	}
 
 	return s.String()
-}
-
-// String returns a string for all of the contents.
-// TODO: Deprecate this, and probably remove the "Contents" type.
-func (cs Contents) String() string {
-	var s strings.Builder
-	d := pktData
-	for _, c := range cs {
-		if d != c.DataPosition {
-			d = c.DataPosition
-			s.WriteString(fmt.Sprintf(" %s;", d))
-		}
-		s.WriteString(fmt.Sprintf(" %s", c))
-	}
-	return strings.TrimSpace(s.String())
 }
 
 // String returns a string for a ByteMatch.

--- a/rule.go
+++ b/rule.go
@@ -46,8 +46,6 @@ type Rule struct {
 	// References contains references associated to the rule (e.g. CVE number).
 	References []*Reference
 	// Contents are all the decoded content matches.
-	PCREs []*PCRE
-	// Tags is a map of tag names to tag values (e.g. classtype:trojan).
 	Tags map[string]string
 	// Statements is a slice of string. These items are similar to Tags, but have no value. (e.g. 'sameip;')
 	Statements []string
@@ -476,6 +474,17 @@ func (r *Rule) ByteMatchers() []*ByteMatch {
 		}
 	}
 	return bs
+}
+
+// PCREs returns all *PCRE for a rule.
+func (r *Rule) PCREs() []*PCRE {
+	var ps []*PCRE
+	for _, m := range r.Matchers {
+		if p, ok := m.(*PCRE); ok {
+			ps = append(ps, p)
+		}
+	}
+	return ps
 }
 
 func netString(netPart []string) string {

--- a/rule_test.go
+++ b/rule_test.go
@@ -580,103 +580,6 @@ func TestContentString(t *testing.T) {
 	}
 }
 
-func TestContentsString(t *testing.T) {
-	for _, tt := range []struct {
-		name  string
-		input Contents
-		want  string
-	}{
-		{
-			name: "single simple content",
-			input: Contents{
-				&Content{
-					Pattern: []byte("AA"),
-				},
-			},
-			want: `content:"AA";`,
-		},
-		{
-			name: "multiple simple contents",
-			input: Contents{
-				&Content{
-					Pattern: []byte("AA"),
-				},
-				&Content{
-					Pattern: []byte("BB"),
-				},
-				&Content{
-					Pattern: []byte("CC"),
-				},
-			},
-			want: `content:"AA"; content:"BB"; content:"CC";`,
-		},
-		{
-			name: "single sticky buffer",
-			input: Contents{
-				&Content{
-					DataPosition: base64Data,
-					Pattern:      []byte("AA"),
-				},
-			},
-			want: `base64_data; content:"AA";`,
-		},
-		{
-			name: "changing sticky buffer",
-			input: Contents{
-				&Content{
-					DataPosition: base64Data,
-					Pattern:      []byte("AA"),
-				},
-				&Content{
-					DataPosition: pktData,
-					Pattern:      []byte("BB"),
-				},
-				&Content{
-					DataPosition: httpAccept,
-					Pattern:      []byte("CC"),
-				},
-			},
-			want: `base64_data; content:"AA"; pkt_data; content:"BB"; http_accept; content:"CC";`,
-		},
-		{
-			name: "changing sticky buffer and complex content",
-			input: Contents{
-				&Content{
-					DataPosition: base64Data,
-					Pattern:      []byte("AA"),
-					FastPattern: FastPattern{
-						Enabled: true,
-					},
-					Options: []*ContentOption{
-						{
-							Name:  "offset",
-							Value: "10",
-						},
-						{
-							Name:  "depth",
-							Value: "50",
-						},
-					},
-				},
-				&Content{
-					DataPosition: pktData,
-					Pattern:      []byte("BB"),
-				},
-				&Content{
-					DataPosition: httpAccept,
-					Pattern:      []byte("CC"),
-				},
-			},
-			want: `base64_data; content:"AA"; offset:10; depth:50; fast_pattern; pkt_data; content:"BB"; http_accept; content:"CC";`,
-		},
-	} {
-		got := tt.input.String()
-		if got != tt.want {
-			t.Fatalf("%s: got %v -- expected %v", tt.name, got, tt.want)
-		}
-	}
-}
-
 func TestPCREString(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
@@ -767,11 +670,6 @@ func TestRuleString(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),
@@ -796,11 +694,6 @@ func TestRuleString(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				PCREs: []*PCRE{
 					{
 						Pattern: []byte("foo.*bar"),
@@ -835,11 +728,6 @@ func TestRuleString(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				Contents: Contents{
-					&Content{
-						Pattern: []byte("AA"),
-					},
-				},
 				Tags: map[string]string{
 					"classtype": "trojan-activity",
 				},

--- a/rule_test.go
+++ b/rule_test.go
@@ -694,12 +694,6 @@ func TestRuleString(t *testing.T) {
 				SID:         1337,
 				Revision:    2,
 				Description: "foo",
-				PCREs: []*PCRE{
-					{
-						Pattern: []byte("foo.*bar"),
-						Options: []byte("Ui"),
-					},
-				},
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte("AA"),


### PR DESCRIPTION
Remove duplicate types from Rule struct that get stored in Matchers (Content, ByteMatcher, PCRE). Replace with functions that can return a slice of those types on demand.