### PR TITLE
Add a new linter for potentially expensive PCRE.

### DIFF
--- a/linters.go
+++ b/linters.go
@@ -15,7 +15,9 @@ limitations under the License.
 
 package gonids
 
-import "strings"
+import (
+	"strings"
+)
 
 // ShouldBeHTTP returns true if a rule looks like the protocol should be http, but is not.
 func (r *Rule) ShouldBeHTTP() bool {
@@ -34,5 +36,77 @@ func (r *Rule) ShouldBeHTTP() bool {
 			}
 		}
 	}
+	return false
+}
+
+// TODO: See if ET folks have any data around this.
+// Minimum lenght of a content to be considered safe for use with a PCRE.
+const minPCREContentLen = 5
+
+// Some of these may be caught by min length check, but including for completeness.
+// All lower case for case insenstive checks.
+// Many of this come from: https://github.com/EmergingThreats/IDSDeathBlossom/blob/master/config/fpblacklist.txt
+var commonStrings = []string{"get",
+	"post",
+	"/",
+	"user-agent",
+	"user-agent: mozilla",
+	"host",
+	"index.php",
+	"index.php?id=",
+	"index.html",
+	"content-length",
+	".htm",
+	".html",
+	".php",
+	".asp",
+	".aspx",
+	"content-disposition",
+	"wp-content/plugins",
+	"wp-content/themes",
+	"activexobject",
+	"default.asp",
+	"default.aspx",
+	"default.asp",
+}
+
+// ExpensivePCRE returns true if a rule appears to use a PCRE without
+// conditions that make it expensive to compute.
+func (r *Rule) ExpensivePCRE() bool {
+	// No PCRE, not expensive.
+	if len(r.PCREs()) < 1 {
+		return false
+	}
+
+	// If we have PCRE, but no contents, this is probably expensive.
+	cs := r.Contents()
+	if len(cs) < 1 {
+		return true
+	}
+
+	// Look for a content with sufficient length to make performance acceptable.
+	short := true
+	for _, c := range cs {
+		// TODO: Identify a sane length.
+		if len(c.Pattern) >= minPCREContentLen {
+			short = false
+		}
+	}
+	if short {
+		return true
+	}
+
+	// If all content matches are common strings, also not good.
+	common := true
+	for _, c := range cs {
+		if !inSlice(strings.ToLower(strings.Trim(string(c.Pattern), "\r\n :/?")), commonStrings) {
+			return false
+		}
+	}
+	if common {
+		return true
+	}
+
+	// Don't flag a rule if we haven't defined a condition that's interesting.
 	return false
 }

--- a/linters.go
+++ b/linters.go
@@ -40,13 +40,13 @@ func (r *Rule) ShouldBeHTTP() bool {
 }
 
 // TODO: See if ET folks have any data around this.
-// Minimum lenght of a content to be considered safe for use with a PCRE.
+// Minimum length of a content to be considered safe for use with a PCRE.
 const minPCREContentLen = 5
 
 // Some of these may be caught by min length check, but including for completeness.
 // All lower case for case insenstive checks.
 // Many of this come from: https://github.com/EmergingThreats/IDSDeathBlossom/blob/master/config/fpblacklist.txt
-var commonStrings = []string{"get",
+var bannedContents = []string{"get",
 	"post",
 	"/",
 	"user-agent",
@@ -99,7 +99,7 @@ func (r *Rule) ExpensivePCRE() bool {
 	// If all content matches are common strings, also not good.
 	common := true
 	for _, c := range cs {
-		if !inSlice(strings.ToLower(strings.Trim(string(c.Pattern), "\r\n :/?")), commonStrings) {
+		if !inSlice(strings.ToLower(strings.Trim(string(c.Pattern), "\r\n :/?")), bannedContents) {
 			return false
 		}
 	}

--- a/linters_test.go
+++ b/linters_test.go
@@ -238,6 +238,35 @@ func TestExpensivePCRE(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "Banned complex content, with long content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("\r\nUser-Agent: "),
+						Options: []*ContentOption{
+							{"http_header", ""},
+						},
+					},
+					&Content{
+						Pattern: []byte("SuperLongUniqueAwesome"),
+					},
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: false,
+		},
 	} {
 		got := tt.input.ExpensivePCRE()
 		// Expected modification.

--- a/linters_test.go
+++ b/linters_test.go
@@ -84,3 +84,165 @@ func TestShouldBeHTTP(t *testing.T) {
 		}
 	}
 }
+
+func TestExpensivePCRE(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input *Rule
+		want  bool
+	}{
+		{
+			name: "No PCRE",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("AAAAAAAAAA"),
+						Options: []*ContentOption{
+							{"http_header", ""},
+						},
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "No Content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Short Content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("AA"),
+						Options: []*ContentOption{
+							{"http_header", ""},
+						},
+					},
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Only Common Content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("POST"),
+						Options: []*ContentOption{
+							{"http_method", ""},
+						},
+					},
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Long Content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("ReallyLongThing"),
+						Options: []*ContentOption{
+							{"http_header", ""},
+						},
+					},
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Banned complex content",
+			input: &Rule{
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"$HTTP_PORTS"},
+				},
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("\r\nUser-Agent: "),
+						Options: []*ContentOption{
+							{"http_header", ""},
+						},
+					},
+					&PCRE{
+						Pattern: []byte("f.*bar"),
+					},
+				},
+			},
+			want: true,
+		},
+	} {
+		got := tt.input.ExpensivePCRE()
+		// Expected modification.
+		if got != tt.want {
+			t.Fatalf("%s: got %v; want %v", tt.name, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
Initial banned keyword list, flag certain conditions for PCRE that might be risky.
This doesn't differentiate the reason for the failure. We may want to consider changing the linter function signature to return err or similar, where we can include specific messages, and flag particular rules.