### PR TITLE
recover in case ReplaceAllStringFunc throws an error

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -41,6 +41,11 @@ var metaSplitRE = regexp.MustCompile(`,\s*`)
 // encoded content.
 func parseContent(content string) ([]byte, error) {
 	// Decode and replace all occurrences of hexadecimal content.
+	defer func() {
+		if r := recover(); r != nil {
+			return []byte{}, r
+		}
+	}()
 	b := hexRE.ReplaceAllStringFunc(content,
 		func(h string) string {
 			r, err := hex.DecodeString(strings.Replace(strings.Trim(h, "|"), " ", "", -1))


### PR DESCRIPTION
I think that `parseContent` should return an error instead of `panic` in case of failure during `ReplaceAllStringFunc`

A rule that can trigger this behavior is 
```
'alert tcp $EXTEVNAL_NET any <> $HOME_NET 0 e:misc-activity; sid:t 2010_09_#alert tcp $EXTERNAL_NET any -> $SQL_SERVERS 1433 (msg:"ET EXPLOIT xp_servicecontrol accecs"; flow:to_%erv23, upd)er,established; content:"x|00|p|00|_|00|s|00|e|00|r|00|v|00|i|00|c|00|e|00|c|00|o|00|n|00|t|00|r|00|o|00|l|00
|"; nocase; reference:url,doc.emergi
```

Found by fuzzing