### PR TITLE
Fix deadlock if signature ends after fast_pattern

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -173,13 +173,17 @@ func (l *lexer) errorf(format string, args ...interface{}) stateFn {
 }
 
 func (l *lexer) unexpectedEOF() stateFn {
-	l.items <- item{itemError, "unexpected EOF"}
+	close(l.items)
 	return nil
 }
 
 // nextItem returns the next item from the input.
 func (l *lexer) nextItem() item {
-	return <-l.items
+	r, more := <-l.items
+	if !more {
+		return item{itemError, "unexpected EOF"}
+	}
+	return r
 }
 
 // lex initializes and runs a new scanner for the input string.

--- a/parser.go
+++ b/parser.go
@@ -476,6 +476,8 @@ func (r *Rule) option(key item, l *lexer) error {
 				}
 				length = i
 			}
+		} else if nextItem.typ == itemError {
+			return errors.New(nextItem.value)
 		}
 		lastContent := r.Contents()[len(r.Contents())-1]
 		lastContent.FastPattern = FastPattern{true, only, offset, length}

--- a/parser.go
+++ b/parser.go
@@ -476,8 +476,6 @@ func (r *Rule) option(key item, l *lexer) error {
 				}
 				length = i
 			}
-		} else if nextItem.typ == itemError {
-			return errors.New(nextItem.value)
 		}
 		lastContent := r.Contents()[len(r.Contents())-1]
 		lastContent.FastPattern = FastPattern{true, only, offset, length}


### PR DESCRIPTION
This is the second issue found by fuzzing.
This is likely similar to https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18669

There may be more generic fixes, like not using a grouting for `l.run()` in lex.go, or closing the channel instead of sending `item{itemError, "unexpected EOF"}` though it

By the way, do you want the fuzz target to be merged in this repository ?