### PR TITLE
Removes leading tabs before parsing commented rule

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -225,7 +225,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 		panic("item is not a comment")
 	}
 	// Pop off all leading # and space, try to parse as rule
-	rule, err := ParseRule(strings.TrimLeft(key.value, "# "))
+	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t"))
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {


### PR DESCRIPTION
So as to avoid over recursion
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18676

Problem comes from mismatch with `case unicode.IsSpace(r):`  in `lexRule`
This leads to an excessive recursion of `comment` and `ParseRule`
I hope the fix is complete
