### PR TITLE
Removes leading vertical tabs before commented rule

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -225,7 +225,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 		panic("item is not a comment")
 	}
 	// Pop off all leading # and space, try to parse as rule
-	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t\v"))
+	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t\v\f"))
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -225,7 +225,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 		panic("item is not a comment")
 	}
 	// Pop off all leading # and space, try to parse as rule
-	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t"))
+	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t\v"))
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {


### PR DESCRIPTION
So as to avoid infinite recursion

You were right @duanehoward here https://github.com/google/gonids/pull/78#issuecomment-549529311
oss-fuzz found it https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18793
after finding the precedent case is fixed