### PR TITLE
Considers CR end of line for commented rule

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -227,7 +227,7 @@ func lexRule(l *lexer) stateFn {
 func lexComment(l *lexer) stateFn {
 	for {
 		switch l.next() {
-		case '\n':
+		case '\r', '\n':
 			l.emit(itemComment, false)
 			return lexRule
 		case eof:


### PR DESCRIPTION
Found by oss-fuzz :
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18819

Bug is similar to https://github.com/google/gonids/pull/82
