### PR TITLE
Fix stringer not handling 7C byte as a | correctly.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -39,6 +39,11 @@ func TestParseContent(t *testing.T) {
 			input: "A|42 43|D| 45|",
 			want:  []byte("ABCDE"),
 		},
+		{
+			name:  "contains hex pipe",
+			input: "A|7C|B",
+			want:  []byte("A|B"),
+		},
 	} {
 		got, err := parseContent(tt.input)
 		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {

--- a/rule.go
+++ b/rule.go
@@ -772,7 +772,7 @@ func (c *Content) FormatPattern() string {
 	var buffer bytes.Buffer
 	pipe := false
 	for _, b := range c.Pattern {
-		if b != ' ' && (b > 126 || b < 35 || b == ':' || b == ';') {
+		if b != ' ' && (b > 126 || b < 35 || b == ':' || b == ';' || b == '|') {
 			if !pipe {
 				buffer.WriteByte('|')
 				pipe = true

--- a/rule_test.go
+++ b/rule_test.go
@@ -87,9 +87,16 @@ func TestContentFormatPattern(t *testing.T) {
 		{
 			name: "double backslash",
 			input: &Content{
-				Pattern: []byte(`C|3a|\\WINDOWS\\system32\\`),
+				Pattern: []byte(`C:\\WINDOWS\\system32\\`),
 			},
-			want: `C|3a|\\WINDOWS\\system32\\`,
+			want: `C|3A|\\WINDOWS\\system32\\`,
+		},
+		{
+			name: "content with hex pipe",
+			input: &Content{
+				Pattern: []byte(`C|B`),
+			},
+			want: `C|7C|B`,
 		},
 	} {
 		got := tt.input.FormatPattern()


### PR DESCRIPTION
0x7C needs special handling for our stringer, otherwise we fail to string out rules that original looked like: content:"foo|7C|bar"