### PR TITLE
Fix stringer for fast_pattern chop mode.

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -527,7 +527,7 @@ func (f FastPattern) String() string {
 	}
 
 	// "only" and "chop" modes are mutually exclusive.
-	if f.Offset != 0 && f.Length != 0 {
+	if f.Offset != 0 || f.Length != 0 {
 		s.WriteString(fmt.Sprintf(":%d,%d", f.Offset, f.Length))
 	}
 

--- a/rule_test.go
+++ b/rule_test.go
@@ -137,6 +137,15 @@ func TestFastPatternString(t *testing.T) {
 			want: "fast_pattern:2,5;",
 		},
 		{
+			name: "fast_pattern:`chop` with 0",
+			input: FastPattern{
+				Enabled: true,
+				Offset:  0,
+				Length:  5,
+			},
+			want: "fast_pattern:0,5;",
+		},
+		{
 			name: "invalid state",
 			input: FastPattern{
 				Enabled: true,


### PR DESCRIPTION
incorrectly used && for len/offset check instead of ||
Added tests.