### PR TITLE
Add support for base64_decode. Add tests.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -1305,7 +1305,7 @@ func TestParseRule(t *testing.T) {
 			},
 		},
 		{
-			name: "negate isdataat",
+			name: "base64 keywords",
 			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"test base64 keywords"; base64_decode:bytes 150,offset 17,relative; base64_data; content:"thing I see"; sid:123; rev:1;)`,
 			want: &Rule{
 				Action:   "alert",

--- a/rule_test.go
+++ b/rule_test.go
@@ -412,6 +412,46 @@ func TestByteMatchString(t *testing.T) {
 	}
 }
 
+func TestBase64DecodeString(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		input ByteMatch
+		want  string
+	}{
+		{
+			name: "base64_decode bare",
+			input: ByteMatch{
+				Kind: b64Decode,
+			},
+			want: `base64_decode;`,
+		},
+		{
+			name: "base64_decode some options",
+			input: ByteMatch{
+				Kind:     b64Decode,
+				NumBytes: 1,
+				Options:  []string{"relative"},
+			},
+			want: `base64_decode:bytes 1,relative;`,
+		},
+		{
+			name: "base64_decode all options",
+			input: ByteMatch{
+				Kind:     b64Decode,
+				NumBytes: 1,
+				Offset:   2,
+				Options:  []string{"relative"},
+			},
+			want: `base64_decode:bytes 1,offset 2,relative;`,
+		},
+	} {
+		got := tt.input.base64DecodeString()
+		if got != tt.want {
+			t.Fatalf("%s: got %v -- expected %v", tt.name, got, tt.want)
+		}
+	}
+}
+
 func TestTLSTagString(t *testing.T) {
 	for _, tt := range []struct {
 		name  string


### PR DESCRIPTION
A bit of a hack shoving this into ByteMatch, but the structures are quite similar. The primary difference is the use of the keywords to identify the values (where others have a set order per type)
This closes #88 