### PR TITLE
Normalize spaces to include unicode ones

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -262,8 +262,10 @@ func (r *Rule) comment(key item, l *lexer) error {
 	if key.typ != itemComment {
 		panic("item is not a comment")
 	}
+	// First normalize spaces, then
 	// Pop off all leading # and space, try to parse as rule
-	rule, err := ParseRule(strings.TrimLeft(key.value, "# \t\v\f"))
+	uncommented := strings.TrimLeft(strings.Join(strings.Fields(key.value), " "), "# ")
+	rule, err := ParseRule(string(uncommented))
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {

--- a/parser.go
+++ b/parser.go
@@ -265,7 +265,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 	// First normalize spaces, then
 	// Pop off all leading # and space, try to parse as rule
 	uncommented := strings.TrimLeft(strings.Join(strings.Fields(key.value), " "), "# ")
-	rule, err := ParseRule(string(uncommented))
+	rule, err := ParseRule(uncommented)
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {


### PR DESCRIPTION
Found by oss-fuzz 
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18897

Related to #84 and previous ones
Fixes the multiple kinds of space problem with normalization hack 
`oneKindOfSpace := strings.Join(strings.Fields(manyKindsOfSpaces), " ")`

Another solution could be to reuse `unicode.IsSpace` and rewrite `strings.TrimLeft` this way :
```
uncommented := []rune(strings.TrimLeft(key.value, "# \t\v\f"))
	for len(uncommented) > 0 {
		if unicode.IsSpace(uncommented[0]) || uncommented[0] == '#' {
			uncommented = uncommented[1:]
		} else {
			break
		}
	}
```