### PR TITLE
Migrate test diffing to use kylelemons/pretty.

### DIFF
--- a/optimize_test.go
+++ b/optimize_test.go
@@ -16,8 +16,10 @@ limitations under the License.
 package gonids
 
 import (
-	"reflect"
+	"fmt"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestOptimizeHTTP(t *testing.T) {
@@ -133,8 +135,9 @@ func TestOptimizeHTTP(t *testing.T) {
 			t.Fatalf("%s: gotMod %v; expected %v", tt.name, gotMod, tt.wantMod)
 		}
 		// Actual modifications correctness.
-		if tt.wantMod && !reflect.DeepEqual(tt.output, tt.input) {
-			t.Fatalf("got:\n%v\nwant:\n%v", tt.input, tt.output)
+		diff := pretty.Compare(tt.output, tt.input)
+		if tt.wantMod && diff != "" {
+			t.Fatal(fmt.Sprintf("diff (-got +want):\n%s", diff))
 		}
 	}
 }
@@ -266,8 +269,9 @@ func TestSnortURILenFix(t *testing.T) {
 			t.Fatalf("%s: gotMod %v; expected %v", tt.name, gotMod, tt.wantMod)
 		}
 		// Actual modifications correctness.
-		if tt.wantMod && !reflect.DeepEqual(tt.output, tt.input) {
-			t.Fatalf("got:\n%v\nwant:\n%v", tt.input, tt.output)
+		diff := pretty.Compare(tt.output, tt.input)
+		if tt.wantMod && diff != "" {
+			t.Fatal(fmt.Sprintf("diff (-got +want):\n%s", diff))
 		}
 	}
 }
@@ -380,8 +384,9 @@ func TestSnortHTTPHeaderFix(t *testing.T) {
 			t.Fatalf("%s: gotMod %v; expected %v", tt.name, gotMod, tt.wantMod)
 		}
 		// Actual modifications correctness.
-		if tt.wantMod && !reflect.DeepEqual(tt.output, tt.input) {
-			t.Fatalf("got:\n%v\nwant:\n%v", tt.input, tt.output)
+		diff := pretty.Compare(tt.output, tt.input)
+		if tt.wantMod && diff != "" {
+			t.Fatal(fmt.Sprintf("diff (-got +want):\n%s", diff))
 		}
 	}
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -16,10 +16,11 @@ limitations under the License.
 package gonids
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 
-	"github.com/davecgh/go-spew/spew"
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestParseContent(t *testing.T) {
@@ -170,8 +171,9 @@ func TestParseLenMatch(t *testing.T) {
 		},
 	} {
 		got, err := parseLenMatch(tt.kind, tt.input)
-		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
-			t.Fatalf("%s: got %v,%v; expected %v,%v", tt.name, got, err, tt.want, tt.wantErr)
+		diff := pretty.Compare(got, tt.want)
+		if diff != "" || (err != nil) != tt.wantErr {
+			t.Fatal(fmt.Sprintf("%s: gotErr:%#v, wantErr:%#v\n diff (-got +want):\n%s", tt.name, err, tt.wantErr, diff))
 		}
 	}
 }
@@ -272,8 +274,9 @@ func TestParseByteMatch(t *testing.T) {
 		},
 	} {
 		got, err := parseByteMatch(tt.kind, tt.input)
-		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
-			t.Fatalf("%s: got %v,%v; expected %v,%v", tt.name, got, err, tt.want, tt.wantErr)
+		diff := pretty.Compare(got, tt.want)
+		if diff != "" || (err != nil) != tt.wantErr {
+			t.Fatal(fmt.Sprintf("%s: gotErr:%#v, wantErr:%#v\n diff (-got +want):\n%s", tt.name, err, tt.wantErr, diff))
 		}
 	}
 }
@@ -325,8 +328,9 @@ func TestParseBase64Decode(t *testing.T) {
 		},
 	} {
 		got, err := parseBase64Decode(tt.kind, tt.input)
-		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
-			t.Fatalf("%s: got %v,%v; expected %v,%v", tt.name, got, err, tt.want, tt.wantErr)
+		diff := pretty.Compare(got, tt.want)
+		if diff != "" || (err != nil) != tt.wantErr {
+			t.Fatal(fmt.Sprintf("%s: gotErr:%#v, wantErr:%#v\n diff (-got +want):\n%s", tt.name, err, tt.wantErr, diff))
 		}
 	}
 }
@@ -1472,8 +1476,9 @@ func TestParseRule(t *testing.T) {
 		},
 	} {
 		got, err := ParseRule(tt.rule)
-		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
-			t.Fatal(spew.Sprintf("%s: got=%#v,%#v; want=%#v,%#v", tt.name, got, err, tt.want, tt.wantErr))
+		diff := pretty.Compare(got, tt.want)
+		if diff != "" || (err != nil) != tt.wantErr {
+			t.Fatal(fmt.Sprintf("%s: gotErr:%#v, wantErr:%#v\n diff (-got +want):\n%s", tt.name, err, tt.wantErr, diff))
 		}
 	}
 }
@@ -1525,8 +1530,9 @@ func TestInEqualOut(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%v", err)
 		}
-		if !reflect.DeepEqual(first, second) {
-			t.Fatalf("%s:\nfirst:\n%#v\n\nsecond:\n%#v\n\nf", tt.name, first, second)
+		diff := pretty.Compare(first, second)
+		if diff != "" {
+			t.Fatal(fmt.Sprintf("%s: diff (-got +want):\n%s", tt.name, diff))
 		}
 	}
 }

--- a/rule_test.go
+++ b/rule_test.go
@@ -16,8 +16,11 @@ limitations under the License.
 package gonids
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/kylelemons/godebug/pretty"
 )
 
 func TestContentToRegexp(t *testing.T) {
@@ -1131,8 +1134,9 @@ func TestInsertMatcher(t *testing.T) {
 		if tt.wantErr != (gotErr != nil) {
 			t.Fatalf("gotErr=%v; wantErr=%v", gotErr != nil, tt.wantErr)
 		}
-		if !reflect.DeepEqual(tt.input, tt.want) {
-			t.Fatalf("got:\n%v\nwant:%v\n", tt.input, tt.want)
+		diff := pretty.Compare(tt.input, tt.want)
+		if diff != "" {
+			t.Fatal(fmt.Sprintf("%s: diff (-got +want):\n%s", tt.name, diff))
 		}
 	}
 }


### PR DESCRIPTION
Move stuct comparison test output to use kylelemons/godebug/pretty for cleaner, more compact diffing of structs in tests. Closes #90 