### PR TITLE
Ignore comment ending rule

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -609,6 +609,10 @@ func ParseRule(rule string) (*Rule, error) {
 	for item := l.nextItem(); item.typ != itemEOR && item.typ != itemEOF && err == nil; item = l.nextItem() {
 		switch item.typ {
 		case itemComment:
+			if r.Action != "" {
+				// Ignore comment ending rule
+				return r, nil
+			}
 			err = r.comment(item, l)
 			// Error here means that the comment was not a commented rule.
 			// So we're not parsing a rule and we need to break out.


### PR DESCRIPTION
Cf https://github.com/google/gonids/pull/92#issuecomment-555985061

So, now rule1 # rule2 gets interpreted as rule 1 instead of disabled rule2
Should fix https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=18999