### PR TITLE
Lexes comment ignoring leading white spaces

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -225,6 +225,18 @@ func lexRule(l *lexer) stateFn {
 
 // lexComment consumes a commented rule.
 func lexComment(l *lexer) stateFn {
+	//ignore leading spaces and #
+	l.ignore()
+	for {
+		r := l.next()
+		if unicode.IsSpace(r) || r == '#' {
+			l.ignore()
+		} else {
+			break
+		}
+	}
+	l.backup()
+
 	for {
 		switch l.next() {
 		case '\r', '\n':

--- a/lex_test.go
+++ b/lex_test.go
@@ -184,7 +184,7 @@ func TestLexer(t *testing.T) {
 		{
 			name:  "comment",
 			input: "# bla",
-			items: []item{{itemComment, "# bla"}},
+			items: []item{{itemComment, "bla"}},
 		},
 		// errors.
 		{

--- a/parser.go
+++ b/parser.go
@@ -328,10 +328,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 	if key.typ != itemComment {
 		panic("item is not a comment")
 	}
-	// First normalize spaces, then
-	// Pop off all leading # and space, try to parse as rule
-	uncommented := strings.TrimLeft(strings.Join(strings.Fields(key.value), " "), "# ")
-	rule, err := ParseRule(uncommented)
+	rule, err := ParseRule(key.value)
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {


### PR DESCRIPTION
Following https://github.com/google/gonids/pull/92#issuecomment-557259735

It seems that the parsing/whitespace removing should rather be done in lex.go than in parser.go

This should be ok with all the problematic cases