### PR TITLE
Fix lexRuleEnd. If we hit this we should just stop.

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -434,8 +434,6 @@ func lexOptionValue(l *lexer) stateFn {
 
 // lexOptionEnd marks the end of a rule.
 func lexRuleEnd(l *lexer) stateFn {
-	l.acceptRun(" \t;")
-	l.ignore()
 	l.emit(itemEOR, false)
 	return lexRule
 }


### PR DESCRIPTION
Closes #100 
We have no need to consume any runes after we hit `)` and we should just emit itemEOR