### PR TITLE
Update network parsing to identify bad input.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -384,12 +384,15 @@ func (r *Rule) protocol(key item, l *lexer) error {
 	return nil
 }
 
-// netSplitRE matches the characters to split a list of networks [$HOME_NET, 192.168.1.1/32] for example.
-var netSplitRE = regexp.MustCompile(`\s*,\s*`)
-
 // network decodes an IDS rule network (networks and ports) based on its key.
 func (r *Rule) network(key item, l *lexer) error {
-	items := netSplitRE.Split(strings.Trim(key.value, "[]"), -1)
+	items := strings.Split(strings.Trim(key.value, "[]"), ",")
+	// Validate that no items contain spaces.
+	for _, i := range items {
+		if len(strings.Fields(i)) > 1 || len(strings.TrimSpace(i)) != len(i) {
+			return fmt.Errorf("network component contains spaces: %v", i)
+		}
+	}
 	switch key.typ {
 	case itemSourceAddress:
 		r.Source.Nets = append(r.Source.Nets, items...)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1696,6 +1696,11 @@ func TestParseRule(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name:    "network with space",
+			rule:    `alert tcp $EXTERNAL_NET 443 -> $HOME_NET [123, 234] (msg:"bad network definition"; sid:4321;)`,
+			wantErr: true,
+		},
+		{
 			name:    "fuzzer generated garbage",
 			rule:    `alert tcp $EXTEVNAL_NET any <> $HOME_NET 0 e:misc-activity; sid:t 2010_09_#alert tcp $EXTERNAL_NET any -> $SQL_SERVERS 1433 (msg:"ET EXPLOIT xp_servicecontrol accecs"; flow:to_%erv23, upd)er,established; content:"x|00|p|00|_|00|s|00|e|00|r|00|v|00|i|00|c|00|e|00|c|00|o|00|n|00|t|00|r|00|o|00|l|00|"; nocase; reference:url,doc.emergi`,
 			wantErr: true,


### PR DESCRIPTION
Identifies input that doesn't appear to be a valid network resource and returns an error instead of trying to compensate by trimming spaces.