### PR TITLE
Preallocates slice for perf reasons

### DIFF
--- a/rule.go
+++ b/rule.go
@@ -482,7 +482,7 @@ func (r *Rule) CVE() string {
 
 // Contents returns all *Content for a rule.
 func (r *Rule) Contents() []*Content {
-	var cs []*Content
+	cs := make([]*Content, 0, len(r.Matchers))
 	for _, m := range r.Matchers {
 		if c, ok := m.(*Content); ok {
 			cs = append(cs, c)


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=19201

Goes down from 46 seconds to 10 seconds on my machine on the input sample
`growslice` used to be where we spent most of the time