### PR TITLE
Adds the fuzz target to the upstream repository

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -1,3 +1,18 @@
+/* Copyright 2019 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package gonids
 
 func FuzzParseRule(data []byte) int {

--- a/fuzz.go
+++ b/fuzz.go
@@ -1,0 +1,11 @@
+package gonids
+
+func FuzzParseRule(data []byte) int {
+	r, err := ParseRule(string(data))
+	if err != nil {
+		// Handle parse error
+		return 0
+	}
+	r.OptimizeHTTP()
+	return 1
+}

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2016 Google Inc.
+/* Copyright 2019 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -1,0 +1,38 @@
+/* Copyright 2016 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gonids
+
+import (
+	"testing"
+)
+
+func TestFuzz(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		rule    string
+	}{
+		{
+			name:    "fuzzer generated garbage",
+			rule:    `alert tcp $EXTEVNAL_NET any <> $HOME_NET 0 e:misc-activity; sid:t 2010_09_#alert tcp $EXTERNAL_NET any -> $SQL_SERVERS 1433 (msg:"ET EXPLOIT xp_servicecontrol accecs"; flow:to_%erv23, upd)er,established; content:"x|00|p|00|_|00|s|00|e|00|r|00|v|00|i|00|c|00|e|00|c|00|o|00|n|00|t|00|r|00|o|00|l|00|"; nocase; reference:url,doc.emergi`,
+		},
+		{
+			name:    "fuzzer goroutines sleep",
+			rule:    `  ert htt $ET any -> Hnz (mjectatay; tls.fingerprint:"65`,
+		},
+	} {
+		FuzzParseRule([]byte(tt.rule))
+	}
+}

--- a/parser_test.go
+++ b/parser_test.go
@@ -1700,16 +1700,6 @@ func TestParseRule(t *testing.T) {
 			rule:    `alert tcp $EXTERNAL_NET 443 -> $HOME_NET [123, 234] (msg:"bad network definition"; sid:4321;)`,
 			wantErr: true,
 		},
-		{
-			name:    "fuzzer generated garbage",
-			rule:    `alert tcp $EXTEVNAL_NET any <> $HOME_NET 0 e:misc-activity; sid:t 2010_09_#alert tcp $EXTERNAL_NET any -> $SQL_SERVERS 1433 (msg:"ET EXPLOIT xp_servicecontrol accecs"; flow:to_%erv23, upd)er,established; content:"x|00|p|00|_|00|s|00|e|00|r|00|v|00|i|00|c|00|e|00|c|00|o|00|n|00|t|00|r|00|o|00|l|00|"; nocase; reference:url,doc.emergi`,
-			wantErr: true,
-		},
-		{
-			name:    "fuzzer goroutines sleep",
-			rule:    `  ert htt $ET any -> Hnz (mjectatay; tls.fingerprint:"65`,
-			wantErr: true,
-		},
 	} {
 		got, err := ParseRule(tt.rule)
 		diff := pretty.Compare(got, tt.want)


### PR DESCRIPTION
The point is to migrate the file from
https://github.com/google/oss-fuzz/blob/master/projects/gonids/fuzz_parserule.go
to this repo, so that it stays synced
cf https://google.github.io/oss-fuzz/advanced-topics/ideal-integration/#summary
_Every fuzz target Is maintained by code owners in their RCS (Git, SVN, etc)._

I moved the tests added after fixing bugs found by fuzzing to the test of this `Fuzz` function 

I can also add a `main` golang package to use but I am not sure you want another package in this repo

I use this reproducer :
```
package main

import (
	"fmt"
	"io/ioutil"
	"os"
	"runtime/pprof"

	"github.com/google/gonids"
)

func main() {
	data, _ := ioutil.ReadFile(os.Args[1])
	f, err := os.Create("cpu.prof")
	if err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	_ = pprof.StartCPUProfile(f)
	gonids.Fuzz(data)
	f.Close()
	pprof.StopCPUProfile()
	f, err = os.Create("heap.prof")
	if err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	if err = pprof.WriteHeapProfile(f); err != nil {
		fmt.Printf("error %#+v\n", err)
		return
	}
	f.Close()
	fmt.Printf("end\n")
}
```