### PR TITLE
Numbytes string

### DIFF
--- a/optimize.go
+++ b/optimize.go
@@ -87,7 +87,7 @@ func (r *Rule) SnortHTTPHeaderFix() bool {
 			if c.SnortHTTPHeader() {
 				modified = true
 				c.Pattern = bytes.TrimSuffix(c.Pattern, []byte("\r\n"))
-				if err := r.InsertMatcher(&ByteMatch{Kind: isDataAt, Negate: true, NumBytes: 1}, i+1); err != nil {
+				if err := r.InsertMatcher(&ByteMatch{Kind: isDataAt, Negate: true, NumBytes: "1"}, i+1); err != nil {
 					return false
 				}
 			}

--- a/optimize_test.go
+++ b/optimize_test.go
@@ -306,7 +306,7 @@ func TestSnortHTTPHeaderFix(t *testing.T) {
 					&ByteMatch{
 						Kind:     isDataAt,
 						Negate:   true,
-						NumBytes: 1,
+						NumBytes: "1",
 					},
 				},
 				Metas: Metadatas{
@@ -359,7 +359,7 @@ func TestSnortHTTPHeaderFix(t *testing.T) {
 					&ByteMatch{
 						Kind:     isDataAt,
 						Negate:   true,
-						NumBytes: 1,
+						NumBytes: "1",
 					},
 					&Content{
 						Pattern: []byte("baz"),

--- a/parser.go
+++ b/parser.go
@@ -655,9 +655,6 @@ func (r *Rule) option(key item, l *lexer) error {
 				}
 			}
 		}
-		// Validate that NumBytes is an int or a variable
-		//
-
 		b.Negate = negate
 
 		r.Matchers = append(r.Matchers, b)

--- a/parser.go
+++ b/parser.go
@@ -634,21 +634,29 @@ func (r *Rule) option(key item, l *lexer) error {
 			if err != nil {
 				return fmt.Errorf("could not parse base64Decode: %v", err)
 			}
+			// base64_decode allows NumBytes to be empty, an int or a variable.
+			if i, err := strconv.Atoi(b.NumBytes); err != nil && b.NumBytes != "" {
+				// NumBytes is not an int, check if it is a variable from byte_extract.
+				if !r.HasVar(b.NumBytes) {
+					return fmt.Errorf("number of bytes is not an int, or an extracted variable: %s; %s", b.NumBytes, err)
+				} else if i < 1 {
+					return fmt.Errorf("bytes must be positive, non-zero values only: %d", i)
+				}
+			}
 		} else {
 			b, err = parseByteMatch(k, nextItem.value)
 			if err != nil {
 				return fmt.Errorf("could not parse byteMatch: %v", err)
 			}
+			if _, err := strconv.Atoi(b.NumBytes); err != nil {
+				// NumBytes is not an int, check if it is a variable from byte_extract.
+				if !r.HasVar(b.NumBytes) {
+					return fmt.Errorf("number of bytes is not an int, or an extracted variable: %s; %s", b.NumBytes, err)
+				}
+			}
 		}
 		// Validate that NumBytes is an int or a variable
-		if i, err := strconv.Atoi(b.NumBytes); err != nil {
-			// NumBytes is not an int, check if it is a variable from byte_extract.
-			if !r.HasVar(b.NumBytes) {
-				return fmt.Errorf("number of bytes is not an int, or an extracted variable: %s; %s", b.NumBytes, err)
-			}
-		} else if i < 1 {
-			return fmt.Errorf("bytes must be positive, non-zero values only: %d", i)
-		}
+		//
 
 		b.Negate = negate
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -192,7 +192,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bExtract,
 			want: &ByteMatch{
 				Kind:     bExtract,
-				NumBytes: 3,
+				NumBytes: "3",
 				Variable: "Certs.len",
 			},
 		},
@@ -202,7 +202,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bExtract,
 			want: &ByteMatch{
 				Kind:     bExtract,
-				NumBytes: 3,
+				NumBytes: "3",
 				Variable: "Certs.len",
 				Options:  []string{"relative", "little"},
 			},
@@ -213,7 +213,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bJump,
 			want: &ByteMatch{
 				Kind:     bJump,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   0,
 			},
 		},
@@ -223,7 +223,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bJump,
 			want: &ByteMatch{
 				Kind:     bJump,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   0,
 				Options:  []string{"relative", "little"},
 			},
@@ -234,7 +234,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bTest,
 			want: &ByteMatch{
 				Kind:     bTest,
-				NumBytes: 2,
+				NumBytes: "2",
 				Operator: "=",
 				Offset:   0,
 				Value:    "0x01",
@@ -246,7 +246,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  bTest,
 			want: &ByteMatch{
 				Kind:     bTest,
-				NumBytes: 4,
+				NumBytes: "4",
 				Operator: "=",
 				Value:    "1337",
 				Offset:   1,
@@ -259,7 +259,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  isDataAt,
 			want: &ByteMatch{
 				Kind:     isDataAt,
-				NumBytes: 4,
+				NumBytes: "4",
 			},
 		},
 		{
@@ -268,7 +268,7 @@ func TestParseByteMatch(t *testing.T) {
 			kind:  isDataAt,
 			want: &ByteMatch{
 				Kind:     isDataAt,
-				NumBytes: 4,
+				NumBytes: "4",
 				Options:  []string{"relative"},
 			},
 		},
@@ -303,7 +303,7 @@ func TestParseBase64Decode(t *testing.T) {
 			kind:  b64Decode,
 			want: &ByteMatch{
 				Kind:     b64Decode,
-				NumBytes: 5,
+				NumBytes: "5",
 			},
 		},
 		{
@@ -321,7 +321,7 @@ func TestParseBase64Decode(t *testing.T) {
 			kind:  b64Decode,
 			want: &ByteMatch{
 				Kind:     b64Decode,
-				NumBytes: 5,
+				NumBytes: "5",
 				Offset:   4,
 				Options:  []string{"relative"},
 			},
@@ -1362,7 +1362,7 @@ func TestParseRule(t *testing.T) {
 					},
 					&ByteMatch{
 						Kind:     bExtract,
-						NumBytes: 3,
+						NumBytes: "3",
 						Variable: "Certs.len",
 						Options:  []string{"relative", "little"},
 					},
@@ -1399,7 +1399,7 @@ func TestParseRule(t *testing.T) {
 					},
 					&ByteMatch{
 						Kind:     bTest,
-						NumBytes: 5,
+						NumBytes: "5",
 						Operator: "<",
 						Value:    "65537",
 						Offset:   0,
@@ -1431,7 +1431,7 @@ func TestParseRule(t *testing.T) {
 					},
 					&ByteMatch{
 						Kind:     bJump,
-						NumBytes: 4,
+						NumBytes: "4",
 						Offset:   0,
 						Options:  []string{"relative", "little", "post_offset -1"},
 					},
@@ -1464,14 +1464,14 @@ func TestParseRule(t *testing.T) {
 					},
 					&ByteMatch{
 						Kind:     bJump,
-						NumBytes: 2,
+						NumBytes: "2",
 						Offset:   3,
 						Options:  []string{"post_offset -1"},
 					},
 					&ByteMatch{
 						Kind:     isDataAt,
 						Negate:   true,
-						NumBytes: 2,
+						NumBytes: "2",
 						Options:  []string{"relative"},
 					},
 				},
@@ -1497,7 +1497,7 @@ func TestParseRule(t *testing.T) {
 				Matchers: []orderedMatcher{
 					&ByteMatch{
 						Kind:     b64Decode,
-						NumBytes: 150,
+						NumBytes: "150",
 						Offset:   17,
 						Options:  []string{"relative"},
 					},

--- a/rule.go
+++ b/rule.go
@@ -627,7 +627,7 @@ func (b ByteMatch) String() string {
 		if b.Negate {
 			s.WriteString("!")
 		}
-		s.WriteString(fmt.Sprintf("%s", b.NumBytes))
+		s.WriteString(b.NumBytes)
 	// Logic for this case is a bit different so it's handled outside.
 	case b64Decode:
 		return b.base64DecodeString()

--- a/rule_test.go
+++ b/rule_test.go
@@ -348,7 +348,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_test basic",
 			input: ByteMatch{
 				Kind:     bTest,
-				NumBytes: 3,
+				NumBytes: "3",
 				Operator: ">",
 				Value:    "300",
 				Offset:   42,
@@ -359,7 +359,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_jump basic",
 			input: ByteMatch{
 				Kind:     bJump,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   42,
 			},
 			want: `byte_jump:3,42;`,
@@ -368,7 +368,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_extract basic",
 			input: ByteMatch{
 				Kind:     bExtract,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   42,
 				Variable: "foobar",
 			},
@@ -378,7 +378,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_test options",
 			input: ByteMatch{
 				Kind:     bTest,
-				NumBytes: 3,
+				NumBytes: "3",
 				Operator: ">",
 				Value:    "300",
 				Offset:   42,
@@ -390,7 +390,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_jump options",
 			input: ByteMatch{
 				Kind:     bJump,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   42,
 				Options:  []string{"relative", "post_offset 2", "bitmask 0x03f0"},
 			},
@@ -400,7 +400,7 @@ func TestByteMatchString(t *testing.T) {
 			name: "byte_extract options",
 			input: ByteMatch{
 				Kind:     bExtract,
-				NumBytes: 3,
+				NumBytes: "3",
 				Offset:   42,
 				Variable: "foobar",
 				Options:  []string{"relative", "bitmask 0x03ff"},
@@ -432,7 +432,7 @@ func TestBase64DecodeString(t *testing.T) {
 			name: "base64_decode some options",
 			input: ByteMatch{
 				Kind:     b64Decode,
-				NumBytes: 1,
+				NumBytes: "1",
 				Options:  []string{"relative"},
 			},
 			want: `base64_decode:bytes 1,relative;`,
@@ -441,7 +441,7 @@ func TestBase64DecodeString(t *testing.T) {
 			name: "base64_decode all options",
 			input: ByteMatch{
 				Kind:     b64Decode,
-				NumBytes: 1,
+				NumBytes: "1",
 				Offset:   2,
 				Options:  []string{"relative"},
 			},
@@ -1096,6 +1096,52 @@ func TestStickyBuffer(t *testing.T) {
 	}
 }
 
+func TestHasVar(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		r    *Rule
+		s    string
+		want bool
+	}{
+		{
+			name: "has var",
+			r: &Rule{
+				Matchers: []orderedMatcher{
+					&ByteMatch{
+						Variable: "foovar",
+					},
+				},
+			},
+			s:    "foovar",
+			want: true,
+		},
+		{
+			name: "has var",
+			r: &Rule{
+				Matchers: []orderedMatcher{
+					&ByteMatch{
+						Variable: "barvar",
+					},
+				},
+			},
+			s:    "foovar",
+			want: false,
+		},
+		{
+			name: "no byte matchers",
+			r:    &Rule{},
+			s:    "foovar",
+			want: false,
+		},
+	} {
+		got := tt.r.HasVar(tt.s)
+		if got != tt.want {
+			t.Fatalf("got=%v; want=%v", got, tt.want)
+		}
+
+	}
+}
+
 func TestInsertMatcher(t *testing.T) {
 	for _, tt := range []struct {
 		name    string
@@ -1201,7 +1247,7 @@ func TestInsertMatcher(t *testing.T) {
 			matcher: &ByteMatch{
 				Kind:     isDataAt,
 				Negate:   true,
-				NumBytes: 1,
+				NumBytes: "1",
 			},
 			pos: 1,
 			want: &Rule{
@@ -1212,7 +1258,7 @@ func TestInsertMatcher(t *testing.T) {
 					&ByteMatch{
 						Kind:     isDataAt,
 						Negate:   true,
-						NumBytes: 1,
+						NumBytes: "1",
 					},
 					&Content{
 						Pattern: []byte("bar"),


### PR DESCRIPTION
Moves `ByteMatch` field `NumBytes` to be string. This allow use of `byte_extract` variables in this field. This also moves validation of `NumBytes` back out to ParseRule to avoid needing to pass in the pointer to the rule to `parseByteMatch()` and `parseBase64Decode()`.