### PR TITLE
Wait for lex goroutine to end

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -173,7 +173,6 @@ func (l *lexer) errorf(format string, args ...interface{}) stateFn {
 }
 
 func (l *lexer) unexpectedEOF() stateFn {
-	close(l.items)
 	return nil
 }
 
@@ -204,6 +203,15 @@ func lex(input string) (*lexer, error) {
 func (l *lexer) run() {
 	for l.state = lexRule; l.state != nil; {
 		l.state = l.state(l)
+	}
+	close(l.items)
+}
+
+func (l *lexer) close() {
+	//reads all items until channel close to be sure goroutine has ended
+	more := true
+	for more {
+		_, more = <-l.items
 	}
 }
 

--- a/lex.go
+++ b/lex.go
@@ -208,7 +208,7 @@ func (l *lexer) run() {
 }
 
 func (l *lexer) close() {
-	//reads all items until channel close to be sure goroutine has ended
+	// Reads all items until channel close to be sure goroutine has ended.
 	more := true
 	for more {
 		_, more = <-l.items

--- a/parser.go
+++ b/parser.go
@@ -700,6 +700,7 @@ func ParseRule(rule string) (*Rule, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer l.close()
 	dataPosition = pktData
 	r := &Rule{}
 	for item := l.nextItem(); item.typ != itemEOR && item.typ != itemEOF && err == nil; item = l.nextItem() {


### PR DESCRIPTION
Allows safe concurrent use without leaving open threads
Useful for fuzzing (stability)