### PR TITLE
Unsupported keys

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -695,7 +695,7 @@ func (r *Rule) option(key item, l *lexer) error {
 		// Don't fail parsing completely, we'll return an error with all keys at the end.
 		unsupportedOptions = append(unsupportedOptions, key.value)
 	}
-	// If we didn't hit any unsupported options, optErr should be nil still.
+	// If we encountered unsupported options, return custom error.
 	if len(unsupportedOptions) > 0 {
 		return &UnsupportedOptionError{
 			Rule:    r,


### PR DESCRIPTION
Adds a custom error type and tracking of unsupported keywords.
This will enable clients to choose what to do when an unsupported keyword is encountered (choose to disable or ignore the rule, or modify it in some way).
The error contains the slice of strings for each unsupported keyword, as well as the rule as it was parsed (best effort)