### PR TITLE
Add support for protocols containing digits (ipv6)

### DIFF
--- a/lex.go
+++ b/lex.go
@@ -281,7 +281,7 @@ func lexProtocol(l *lexer) stateFn {
 		case r == ' ':
 			l.emit(itemProtocol, true)
 			return lexSourceAddress
-		case !(unicode.IsLetter(r) || (l.len() > 0 && r == '-')):
+		case !(unicode.IsLetter(r) || unicode.IsDigit(r) || (l.len() > 0 && r == '-')):
 			return l.errorf("invalid character %q for a rule protocol", r)
 		}
 	}

--- a/lex_test.go
+++ b/lex_test.go
@@ -96,6 +96,22 @@ func TestLexer(t *testing.T) {
 			},
 		},
 		{
+			name:  "protocol with number",
+			input: `alert ipv6 $HOME_NET any -> $EXTERNAL_NET any (key1:"value1";)`,
+			items: []item{
+				{itemAction, "alert"},
+				{itemProtocol, "ipv6"},
+				{itemSourceAddress, "$HOME_NET"},
+				{itemSourcePort, "any"},
+				{itemDirection, "->"},
+				{itemDestinationAddress, "$EXTERNAL_NET"},
+				{itemDestinationPort, "any"},
+				{itemOptionKey, "key1"},
+				{itemOptionValueString, "value1"},
+				{itemEOR, ""},
+			},
+		},
+		{
 			name:  "single key",
 			input: "alert udp $HOME_NET any -> [1.1.1.1,2.2.2.2] any (key;)",
 			items: []item{


### PR DESCRIPTION
Add support for digits in protocols in the lexer
Fixes #118