### PR TITLE
Extends fuzz target by recomputing rule string

### DIFF
--- a/fuzz.go
+++ b/fuzz.go
@@ -23,5 +23,6 @@ func FuzzParseRule(data []byte) int {
 		return 0
 	}
 	r.OptimizeHTTP()
+	r.String()
 	return 1
 }

--- a/fuzz.go
+++ b/fuzz.go
@@ -23,6 +23,6 @@ func FuzzParseRule(data []byte) int {
 		return 0
 	}
 	r.OptimizeHTTP()
-	r.String()
+	_ = r.String()
 	return 1
 }


### PR DESCRIPTION
To maximize coverage

This should extend coverage in rule.go
We could include other functions such as `ExpensivePCRE`
