### PR TITLE
Forbids multiple commentsfor rules with empty action

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -339,6 +339,10 @@ func (r *Rule) comment(key item, l *lexer) error {
 	if key.typ != itemComment {
 		panic("item is not a comment")
 	}
+	if r.Disabled {
+		// ignoring comment for rule with empty action
+		return nil
+	}
 	rule, err := ParseRule(key.value)
 
 	// If there was an error this means the comment is not a rule.


### PR DESCRIPTION
Found by oss-fuzz
Prevents over recursion

Sample is 
`#" t 2 " ->   (content:";fast_pattern)#" t 0 " ->   (content:";fast_pattern)##" t 2 " -> `

Condition https://github.com/google/gonids/blob/master/parser.go#L726
is to enough because we can have an empty action