### PR TITLE
Add support for startswith and endswith keywords.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -551,7 +551,7 @@ func (r *Rule) option(key item, l *lexer) error {
 		}
 	case inSlice(key.value, []string{"http_cookie", "http_raw_cookie", "http_method", "http_header", "http_raw_header",
 		"http_uri", "http_raw_uri", "http_user_agent", "http_stat_code", "http_stat_msg",
-		"http_client_body", "http_server_body", "http_host", "nocase", "rawbytes"}):
+		"http_client_body", "http_server_body", "http_host", "nocase", "rawbytes", "startswith", "endswith"}):
 		lastContent := r.LastContent()
 		if lastContent == nil {
 			return fmt.Errorf("invalid content option %q with no content match", key.value)

--- a/parser_test.go
+++ b/parser_test.go
@@ -1665,6 +1665,62 @@ func TestParseRule(t *testing.T) {
 				},
 			},
 		},
+		// Begin Suricata 5.0 features.
+		{
+			name: "startswith",
+			rule: `alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"startswith test"; content:"foo"; startswith; sid:1234; rev:2;)`,
+			want: &Rule{
+				Action:   "alert",
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
+				SID:         1234,
+				Revision:    2,
+				Description: "startswith test",
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("foo"),
+						Options: []*ContentOption{
+							{"startswith", ""},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "startswith and endswith",
+			rule: `alert http $HOME_NET any -> $EXTERNAL_NET any (msg:"start and end test"; content:"foo"; startswith; endswith; sid:1234; rev:2;)`,
+			want: &Rule{
+				Action:   "alert",
+				Protocol: "http",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
+				SID:         1234,
+				Revision:    2,
+				Description: "start and end test",
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte("foo"),
+						Options: []*ContentOption{
+							{"startswith", ""},
+							{"endswith", ""},
+						},
+					},
+				},
+			},
+		},
 		// Errors
 		{
 			name:    "invalid direction",


### PR DESCRIPTION
First commit toward #125 supporting Suricata 5.0 rule sets.