### PR TITLE
Make LenMatcher and orderedMatcher.

### DIFF
--- a/optimize.go
+++ b/optimize.go
@@ -49,7 +49,7 @@ func (r *Rule) OptimizeHTTP() bool {
 func (r *Rule) SnortURILenFix() bool {
 	var modified bool
 	// Update this once we parse urilen in a better structure.
-	for _, l := range r.LenMatchers {
+	for _, l := range r.LenMatchers() {
 		if l.Kind == uriLen && l.Operator == "<>" {
 			l.Min--
 			l.Max++

--- a/optimize_test.go
+++ b/optimize_test.go
@@ -152,8 +152,8 @@ func TestSnortURILenFix(t *testing.T) {
 		{
 			name: "urilen exact raw",
 			input: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:    uriLen,
 						Num:     3,
 						Options: []string{"raw"},
@@ -165,8 +165,8 @@ func TestSnortURILenFix(t *testing.T) {
 		{
 			name: "urilen exact norm",
 			input: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:    uriLen,
 						Num:     3,
 						Options: []string{"norm"},
@@ -178,8 +178,8 @@ func TestSnortURILenFix(t *testing.T) {
 		{
 			name: "urilen range",
 			input: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     uriLen,
 						Min:      3,
 						Max:      7,
@@ -188,8 +188,8 @@ func TestSnortURILenFix(t *testing.T) {
 				},
 			},
 			output: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     uriLen,
 						Min:      2,
 						Max:      8,
@@ -208,16 +208,16 @@ func TestSnortURILenFix(t *testing.T) {
 		{
 			name: "urilen exact",
 			input: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind: uriLen,
 						Num:  3,
 					},
 				},
 			},
 			output: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:    uriLen,
 						Num:     3,
 						Options: []string{"raw"},
@@ -234,8 +234,8 @@ func TestSnortURILenFix(t *testing.T) {
 		{
 			name: "urilen range norm",
 			input: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     uriLen,
 						Min:      3,
 						Max:      7,
@@ -245,8 +245,8 @@ func TestSnortURILenFix(t *testing.T) {
 				},
 			},
 			output: &Rule{
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     uriLen,
 						Min:      2,
 						Max:      8,

--- a/parser.go
+++ b/parser.go
@@ -672,7 +672,8 @@ func (r *Rule) option(key item, l *lexer) error {
 		if err != nil {
 			return fmt.Errorf("could not parse LenMatch: %v", err)
 		}
-		r.LenMatchers = append(r.LenMatchers, m)
+		m.DataPosition = dataPosition
+		r.Matchers = append(r.Matchers, m)
 	case key.value == "flowbits":
 		nextItem := l.nextItem()
 		fb, err := parseFlowbit(nextItem.value)

--- a/parser_test.go
+++ b/parser_test.go
@@ -732,8 +732,8 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     dSize,
 						Operator: ">",
 						Num:      19,
@@ -757,8 +757,8 @@ func TestParseRule(t *testing.T) {
 				},
 				SID:         1337,
 				Description: "foo",
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     uriLen,
 						Operator: "<>",
 						Min:      2,
@@ -809,8 +809,8 @@ func TestParseRule(t *testing.T) {
 				SID:         1337,
 				Revision:    1,
 				Description: "foo",
-				LenMatchers: []*LenMatch{
-					{
+				Matchers: []orderedMatcher{
+					&LenMatch{
 						Kind:     iType,
 						Operator: ">",
 						Num:      10,


### PR DESCRIPTION
Refactoring in support of #125 this refactor allows LenMatch to become an orderedMatcher which is required for us to support the `bsize` keyword (since it operates on a sticky buffer).