### PR TITLE
Turning dry_run off for CIFuzz

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -8,13 +8,13 @@ jobs:
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
      with:
        oss-fuzz-project-name: 'gonids'
-       dry-run: true
+       dry-run: false
    - name: Run Fuzzers
      uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
      with:
        oss-fuzz-project-name: 'gonids'
        fuzz-seconds: 600
-       dry-run: true
+       dry-run: false
    - name: Upload Crash
      uses: actions/upload-artifact@v1
      if: failure()


### PR DESCRIPTION
This will allow CIFuzz to report crashes when they are detected. 