### PR TITLE
Avoids over recursion in ParseRule

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -715,7 +715,7 @@ func (uoe *UnsupportedOptionError) Error() string {
 	return fmt.Sprintf("rule contains unsupported option(s): %s", strings.Join(uoe.Options, ","))
 }
 
-// ParseRule parses an IDS rule and returns a struct describing the rule.
+// parseRuleAux parses an IDS rule, optionally ignoring comments.
 func parseRuleAux(rule string, commented bool) (*Rule, error) {
 	l, err := lex(rule)
 	if err != nil {
@@ -776,6 +776,7 @@ func parseRuleAux(rule string, commented bool) (*Rule, error) {
 	return r, nil
 }
 
+// ParseRule parses an IDS rule and returns a struct describing the rule.
 func ParseRule(rule string) (*Rule, error) {
 	return parseRuleAux(rule, false)
 }

--- a/parser.go
+++ b/parser.go
@@ -343,7 +343,7 @@ func (r *Rule) comment(key item, l *lexer) error {
 		// ignoring comment for rule with empty action
 		return nil
 	}
-	rule, err := ParseRule(key.value)
+	rule, err := parseRuleAux(key.value, true)
 
 	// If there was an error this means the comment is not a rule.
 	if err != nil {
@@ -716,7 +716,7 @@ func (uoe *UnsupportedOptionError) Error() string {
 }
 
 // ParseRule parses an IDS rule and returns a struct describing the rule.
-func ParseRule(rule string) (*Rule, error) {
+func parseRuleAux(rule string, commented bool) (*Rule, error) {
 	l, err := lex(rule)
 	if err != nil {
 		return nil, err
@@ -728,7 +728,7 @@ func ParseRule(rule string) (*Rule, error) {
 	for item := l.nextItem(); item.typ != itemEOR && item.typ != itemEOF && err == nil; item = l.nextItem() {
 		switch item.typ {
 		case itemComment:
-			if r.Action != "" {
+			if r.Action != "" || commented {
 				// Ignore comment ending rule.
 				return r, nil
 			}
@@ -774,4 +774,8 @@ func ParseRule(rule string) (*Rule, error) {
 	}
 
 	return r, nil
+}
+
+func ParseRule(rule string) (*Rule, error) {
+	return parseRuleAux(rule, false)
 }


### PR DESCRIPTION
Found by oss-fuzz :
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=21920

We no not need to parse a comment from a commented

Hope this is right this time :-)