### PR TITLE
Fix Content FormatPattern to handle backslashes.

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -52,6 +52,10 @@ func parseContent(content string) ([]byte, error) {
 		}
 	}()
 
+	if containsUnescaped(content) {
+		return nil, fmt.Errorf("invalid special characters escaping")
+	}
+
 	b := escapeContent.ReplaceAllString(content, "$1")
 
 	b = hexRE.ReplaceAllStringFunc(b,
@@ -322,6 +326,33 @@ func parseFlowint(s string) (*Flowint, error) {
 	}
 
 	return fi, nil
+}
+
+// containsUnescaped checks content whether special characters are properly escaped.
+func containsUnescaped(s string) bool {
+	esc := false
+
+	for _, b := range s {
+		if esc {
+			switch b {
+			case '\\', ';', '"', ':':
+				esc = false
+				break
+			default:
+				return true
+			}
+		} else {
+			switch b {
+			case '\\':
+				esc = true
+				break
+			case ';', '"', ':':
+				return true
+			}
+		}
+	}
+
+	return esc
 }
 
 func unquote(s string) string {

--- a/parser.go
+++ b/parser.go
@@ -34,6 +34,9 @@ var hexRE = regexp.MustCompile(`(?i)(\|(?:\s*[a-f0-9]{2}\s*)+\|)`)
 // escapeRE matches char that needs to escaped in regexp.
 var escapeRE = regexp.MustCompile(`([()+.'\\])`)
 
+// escapeContent matches escaped special characters.
+var escapeContent = regexp.MustCompile(`\\([\\;":])`)
+
 // metaSplitRE matches string in metadata
 var metaSplitRE = regexp.MustCompile(`,\s*`)
 
@@ -48,7 +51,10 @@ func parseContent(content string) ([]byte, error) {
 			errpanic = fmt.Errorf("recovered from panic: %v", r)
 		}
 	}()
-	b := hexRE.ReplaceAllStringFunc(content,
+
+	b := escapeContent.ReplaceAllString(content, "$1")
+
+	b = hexRE.ReplaceAllStringFunc(b,
 		func(h string) string {
 			r, err := hex.DecodeString(strings.Replace(strings.Trim(h, "|"), " ", "", -1))
 			if err != nil {

--- a/parser_test.go
+++ b/parser_test.go
@@ -45,6 +45,16 @@ func TestParseContent(t *testing.T) {
 			input: "A|7C|B",
 			want:  []byte("A|B"),
 		},
+		{
+			name:  "contains escaped backslash",
+			input: `A\\B`,
+			want:  []byte(`A\B`),
+		},
+		{
+			name:  "contains multiple escaped characters",
+			input: `A\\\;\"\\\:B`,
+			want:  []byte(`A\;"\:B`),
+		},
 	} {
 		got, err := parseContent(tt.input)
 		if !reflect.DeepEqual(got, tt.want) || (err != nil) != tt.wantErr {
@@ -1548,6 +1558,29 @@ func TestParseRule(t *testing.T) {
 				Matchers: []orderedMatcher{
 					&Content{
 						Pattern: []byte{0x66, 0x6f, 0x6f, 0x5c},
+					},
+				},
+			},
+		},
+		{
+			name: "content with escaped characters",
+			rule: `alert tcp $HOME_NET any -> $EXTERNAL_NET any (msg:"escaped characters"; content:"A\\B\;C\"\:"; sid:7; rev:1;)`, want: &Rule{
+				Action:   "alert",
+				Protocol: "tcp",
+				Source: Network{
+					Nets:  []string{"$HOME_NET"},
+					Ports: []string{"any"},
+				},
+				Destination: Network{
+					Nets:  []string{"$EXTERNAL_NET"},
+					Ports: []string{"any"},
+				},
+				SID:         7,
+				Revision:    1,
+				Description: "escaped characters",
+				Matchers: []orderedMatcher{
+					&Content{
+						Pattern: []byte{0x41, 0x5c, 0x42, 0x3b, 0x43, 0x22, 0x3a},
 					},
 				},
 			},

--- a/rule.go
+++ b/rule.go
@@ -990,7 +990,7 @@ func (c *Content) FormatPattern() string {
 	var buffer bytes.Buffer
 	pipe := false
 	for _, b := range c.Pattern {
-		if b != ' ' && (b > 126 || b < 35 || b == ':' || b == ';' || b == '|') {
+		if b != ' ' && (b > 126 || b < 35 || b == ':' || b == ';' || b == '|' || b == '\\') {
 			if !pipe {
 				buffer.WriteByte('|')
 				pipe = true

--- a/rule_test.go
+++ b/rule_test.go
@@ -92,7 +92,7 @@ func TestContentFormatPattern(t *testing.T) {
 			input: &Content{
 				Pattern: []byte(`C:\\WINDOWS\\system32\\`),
 			},
-			want: `C|3A|\\WINDOWS\\system32\\`,
+			want: `C|3A 5C 5C|WINDOWS|5C 5C|system32|5C 5C|`,
 		},
 		{
 			name: "content with hex pipe",

--- a/rule_test.go
+++ b/rule_test.go
@@ -88,11 +88,11 @@ func TestContentFormatPattern(t *testing.T) {
 			want: "abcd|3B 3A 0D 0A|e|0D|f",
 		},
 		{
-			name: "double backslash",
+			name: "backslash",
 			input: &Content{
-				Pattern: []byte(`C:\\WINDOWS\\system32\\`),
+				Pattern: []byte(`C:\WINDOWS\system32\`),
 			},
-			want: `C|3A 5C 5C|WINDOWS|5C 5C|system32|5C 5C|`,
+			want: `C|3A 5C|WINDOWS|5C|system32|5C|`,
 		},
 		{
 			name: "content with hex pipe",
@@ -100,6 +100,13 @@ func TestContentFormatPattern(t *testing.T) {
 				Pattern: []byte(`C|B`),
 			},
 			want: `C|7C|B`,
+		},
+		{
+			name: "escaped characters",
+			input: &Content{
+				Pattern: []byte(`A\B;C":`),
+			},
+			want: `A|5C|B|3B|C|22 3A|`,
 		},
 	} {
 		got := tt.input.FormatPattern()


### PR DESCRIPTION
Solves #147 

+ updates tests

`double backslash` in `TestContentFormatPattern` outputed `C|3A|\\WINDOWS\\system32\\` which in reality were not double backslashes but escaped single backslashes