### PR TITLE
Unescaped error consistency w/ docs

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -344,7 +344,7 @@ func containsUnescaped(s string) bool {
 			switch b {
 			case '\\':
 				esc = true
-			case ';', '"', ':':
+			case ';', '"':
 				return true
 			}
 		}


### PR DESCRIPTION
Hi, after reading [code for content parsing in Suricata](https://github.com/OISF/suricata/blob/master/src/detect-content.c#L82) I realized colon can be present both in escaped way and unescaped so I changed the `containsUnescaped` to reflect this. Actually, the same case it is for semi-colon but as it is [explicitely mentioned in docs](https://suricata.readthedocs.io/en/latest/rules/intro.html#rule-options) that it should be escaped I decide to keep it as error (+ there is no unescaped semi-colon in ET OPEN as oppose to unescaped colons which are present in many ET OPEN rules).

[Here](https://github.com/OISF/suricata/blob/master/src/detect-content.c#L151) it can be parsed as escaped character.

[Here](https://github.com/OISF/suricata/blob/master/src/detect-content.c#L167) it can be parsed as unescaped character.

[Here](https://github.com/OISF/suricata/blob/master/src/detect-content.c#L164) you can see that actually only character that must be escaped (except backslash which is handled in earlier condition) are double quotes.