### PR TITLE
Add DataPosition for PCRE

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -802,6 +802,7 @@ func (r *Rule) option(key item, l *lexer) error {
 			if err != nil {
 				return err
 			}
+			p.DataPosition = dataPosition
 			p.Negate = negate
 			r.Matchers = append(r.Matchers, p)
 		} else {

--- a/rule.go
+++ b/rule.go
@@ -494,9 +494,12 @@ type LenMatch struct {
 
 // PCRE describes a PCRE item of a rule.
 type PCRE struct {
-	Pattern []byte
-	Negate  bool
-	Options []byte
+	// DataPosition defaults to pkt_data state, can be modified to apply to file_data, base64_data locations.
+	// This value will apply to all following contents, to reset to default you must reset DataPosition during processing.
+	DataPosition DataPos
+	Pattern      []byte
+	Negate       bool
+	Options      []byte
 }
 
 // FastPattern describes various properties of a fast_pattern value for a content.
@@ -916,6 +919,12 @@ func (r Rule) String() string {
 				}
 			}
 			if c, ok := m.(*LenMatch); ok {
+				if d != c.DataPosition {
+					d = c.DataPosition
+					s.WriteString(fmt.Sprintf("%s; ", d))
+				}
+			}
+			if c, ok := m.(*PCRE); ok {
 				if d != c.DataPosition {
 					d = c.DataPosition
 					s.WriteString(fmt.Sprintf("%s; ", d))


### PR DESCRIPTION
Previously, a rule such as:
`alert tcp $EXTERNAL_NET any -> $HTTP_SERVERS $HTTP_PORTS (msg:"SERVER-IIS Malformed Hit-Highlighting Argument File Access Attempt"; flow:to_server,established; http.uri; content:"CiWebHitsFile="; nocase; pkt_data; pcre:"/CiWebHitsFile=\/?([^\r\n\x3b\&]*\.\.\/)?/i"; http.uri; content:"CiRestriction=none"; nocase; fast_pattern; content:"ciHiliteType=Full"; nocase; metadata:ruleset community, service http; classtype:web-application-attack; reference:bugtraq,950; reference:cve,2000-0097; reference:url,technet.microsoft.com/en-us/security/bulletin/ms00-006; reference:url,www.securityfocus.com/archive/1/43762; sid:1019; rev:30;)`
would not be parsed completely, resulting in a loss of information about which buffer the `pcre` expression should be matched against.